### PR TITLE
Implement auth and role-aware session shell for #15

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { SafeAreaView, ScrollView, Text, useWindowDimensions, View } from "react-native";
 
+import { StaffAccessModal } from "./src/components/StaffAccessModal";
 import { GhostButton, MetricCard } from "./src/components/ui";
 import { useStageHandState } from "./src/hooks/useStageHandState";
 import { useWorkspaceSession } from "./src/hooks/useWorkspaceSession";
@@ -8,6 +9,7 @@ import { CrowdView } from "./src/screens/CrowdView";
 import { LaunchScreen } from "./src/screens/LaunchScreen";
 import { ManagerView } from "./src/screens/ManagerView";
 import { MemberView } from "./src/screens/MemberView";
+import { UnlockScreen } from "./src/screens/UnlockScreen";
 import { appStyles as styles } from "./src/styles/appStyles";
 
 function App() {
@@ -15,11 +17,36 @@ function App() {
   const isTablet = width >= 900;
   const stagehand = useStageHandState();
   const session = useWorkspaceSession();
+  const [staffAccessVisible, setStaffAccessVisible] = React.useState(false);
+  const appReady = stagehand.hydrated && session.hydrated;
 
   const activeRole = session.activeRole;
+  const provisionedRole = session.deviceSession?.role ?? null;
+  const shellState = appReady ? session.shellState : "hydrating";
+
+  const workspaceTitle =
+    provisionedRole === "crowd"
+      ? stagehand.state.access.crowdLabel || "Crowd tablet"
+      : provisionedRole === "manager"
+        ? "Manager"
+        : provisionedRole === "member"
+          ? "Band member"
+          : "Device setup";
 
   return (
     <SafeAreaView style={styles.safeArea}>
+      <StaffAccessModal
+        visible={staffAccessVisible}
+        onCancel={() => setStaffAccessVisible(false)}
+        onConfirm={async (passcode) => {
+          const succeeded = await session.exitCrowdMode(passcode, stagehand.state.access);
+          if (succeeded) {
+            setStaffAccessVisible(false);
+          }
+          return succeeded;
+        }}
+      />
+
       <ScrollView style={styles.screen} contentContainerStyle={styles.screenContent}>
         <View style={styles.hero}>
           <View style={styles.heroMain}>
@@ -55,35 +82,42 @@ function App() {
           </View>
         </View>
 
-        {session.hydrated && activeRole ? (
+        {shellState === "active" && activeRole !== "crowd" ? (
           <View style={styles.workspaceHeader}>
             <View style={styles.workspaceHeaderCopy}>
-              <Text style={styles.eyebrow}>Current workspace</Text>
-              <Text style={styles.workspaceTitle}>
-                {activeRole === "crowd"
-                  ? stagehand.state.access.crowdLabel || "Crowd tablet"
-                  : activeRole === "manager"
-                    ? "Manager"
-                    : "Band member"}
-              </Text>
+              <Text style={styles.eyebrow}>Current device session</Text>
+              <Text style={styles.workspaceTitle}>{workspaceTitle}</Text>
             </View>
-            <GhostButton
-              label="Change device mode"
-              onPress={() => {
-                void session.setActiveRole(null);
-              }}
-            />
+            <View style={styles.workspaceActionGroup}>
+              <GhostButton label="Lock device" onPress={session.lockWorkspace} />
+              <GhostButton
+                label="Change device mode"
+                onPress={() => {
+                  void session.clearDeviceSession();
+                }}
+              />
+            </View>
           </View>
         ) : null}
 
-        {session.hydrated && !activeRole ? (
+        {shellState === "setup" ? (
           <LaunchScreen
             access={stagehand.state.access}
-            onEnterRole={(role) => session.setActiveRole(role)}
+            onProvisionRole={(role) => session.provisionRole(role)}
           />
         ) : null}
 
-        {activeRole === "manager" ? (
+        {shellState === "locked" && provisionedRole && provisionedRole !== "crowd" ? (
+          <UnlockScreen
+            role={provisionedRole}
+            onUnlock={(passcode) => session.unlockWorkspace(passcode, stagehand.state.access)}
+            onReprovision={() => {
+              void session.clearDeviceSession();
+            }}
+          />
+        ) : null}
+
+        {shellState === "active" && activeRole === "manager" ? (
           <ManagerView
             activeShow={stagehand.activeShow}
             helpers={stagehand.helpers}
@@ -95,7 +129,7 @@ function App() {
           />
         ) : null}
 
-        {activeRole === "member" ? (
+        {shellState === "active" && activeRole === "member" ? (
           <MemberView
             activeShow={stagehand.activeShow}
             helpers={stagehand.helpers}
@@ -105,20 +139,32 @@ function App() {
           />
         ) : null}
 
-        {activeRole === "crowd" ? (
+        {shellState === "active" && activeRole === "crowd" ? (
           <CrowdView
             activeShow={stagehand.activeShow}
             bandName={stagehand.state.bandName}
             boostRequest={stagehand.actions.boostRequest}
+            crowdLabel={stagehand.state.access.crowdLabel || "Crowd workspace"}
             helpers={stagehand.helpers}
             isTablet={isTablet}
             links={stagehand.state.links}
+            onRequestStaffAccess={() => setStaffAccessVisible(true)}
             addRequest={(payload) => stagehand.actions.addRequest(payload)}
             addSupportTip={(payload) => stagehand.actions.addSupportTip(payload)}
             songs={stagehand.state.songs}
             sortedRequests={stagehand.sortedRequests}
             supportTips={stagehand.state.supportTips}
           />
+        ) : null}
+
+        {shellState === "hydrating" ? (
+          <View style={styles.card}>
+            <Text style={styles.eyebrow}>Loading session</Text>
+            <Text style={styles.cardTitle}>Restoring this device</Text>
+            <Text style={styles.leadCopy}>
+              StageHand is checking the local device session and workspace state.
+            </Text>
+          </View>
         ) : null}
       </ScrollView>
     </SafeAreaView>

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Then open the project in Expo Go or a simulator:
 
 - Expo SDK 55 project scaffold with React Native 0.83 and React 19.2 alignment
 - Local persistence with AsyncStorage so seeded demo data survives app restarts
+- Role-aware local device session shell with provisioning, protected unlock, and crowd kiosk exit
 - Shared in-memory model for songs, members, shows, request queue, and support tips
 - Responsive layout logic that gives the crowd view a tablet-optimized split pane
 - Native-friendly UI built with core React Native components only
@@ -33,8 +34,9 @@ Then open the project in Expo Go or a simulator:
 
 ## Project structure
 
-- `App.tsx`: app shell, role switcher, and top-level composition
+- `App.tsx`: app shell, device-session routing, and top-level composition
 - `src/hooks/useStageHandState.ts`: shared local state, persistence, and state actions
+- `src/hooks/useWorkspaceSession.ts`: local device-session and protected shell logic
 - `src/screens/`: manager, member, and crowd experiences
 - `src/components/`: reusable UI primitives and role switcher
 - `src/lib/` and `src/types/`: seed data, helpers, and shared types

--- a/src/components/StaffAccessModal.tsx
+++ b/src/components/StaffAccessModal.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from "react";
+import { Modal, Text, View } from "react-native";
+
+import { GhostButton, PrimaryButton, TextInputField } from "./ui";
+import { appStyles as styles } from "../styles/appStyles";
+
+export function StaffAccessModal({
+  onCancel,
+  onConfirm,
+  visible,
+}: {
+  onCancel: () => void;
+  onConfirm: (passcode: string) => Promise<boolean>;
+  visible: boolean;
+}) {
+  const [passcode, setPasscode] = useState("");
+  const [error, setError] = useState("");
+
+  const handleCancel = () => {
+    setPasscode("");
+    setError("");
+    onCancel();
+  };
+
+  const handleConfirm = async () => {
+    const succeeded = await onConfirm(passcode);
+    if (!succeeded) {
+      setError("Passcode did not match staff access.");
+      return;
+    }
+
+    setPasscode("");
+    setError("");
+  };
+
+  return (
+    <Modal animationType="fade" transparent visible={visible} onRequestClose={handleCancel}>
+      <View style={styles.modalBackdrop}>
+        <View style={styles.modalCard}>
+          <Text style={styles.eyebrow}>Staff access</Text>
+          <Text style={styles.modalTitle}>Exit crowd kiosk mode?</Text>
+          <Text style={styles.modalBody}>
+            Enter the manager passcode to clear the crowd tablet session and return this device to
+            setup.
+          </Text>
+
+          <TextInputField
+            label="Manager passcode"
+            value={passcode}
+            keyboardType="numeric"
+            onChangeText={(text) => {
+              setPasscode(text);
+              if (error) {
+                setError("");
+              }
+            }}
+          />
+
+          {error ? <Text style={styles.errorText}>{error}</Text> : null}
+
+          <View style={styles.actionRow}>
+            <GhostButton label="Cancel" onPress={handleCancel} />
+            <PrimaryButton
+              label="Continue"
+              onPress={() => {
+                void handleConfirm();
+              }}
+            />
+          </View>
+        </View>
+      </View>
+    </Modal>
+  );
+}

--- a/src/hooks/useWorkspaceSession.ts
+++ b/src/hooks/useWorkspaceSession.ts
@@ -1,20 +1,36 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useEffect, useState } from "react";
 
-import { Role } from "../types/stagehand";
+import { AccessSettings, DeviceSession, ProtectedRole, Role } from "../types/stagehand";
 
-const SESSION_KEY = "stagehand-workspace-session-v1";
+const SESSION_KEY = "stagehand-device-session-v2";
+
+type WorkspaceShellState = "hydrating" | "setup" | "locked" | "active";
 
 export function useWorkspaceSession() {
-  const [activeRole, setActiveRoleState] = useState<Role | null>(null);
+  const [deviceSession, setDeviceSession] = useState<DeviceSession | null>(null);
   const [hydrated, setHydrated] = useState(false);
+  const [isUnlocked, setIsUnlocked] = useState(false);
 
   useEffect(() => {
     const hydrate = async () => {
       try {
         const raw = await AsyncStorage.getItem(SESSION_KEY);
-        if (raw === "manager" || raw === "member" || raw === "crowd") {
-          setActiveRoleState(raw);
+        if (raw) {
+          const parsed = JSON.parse(raw) as Partial<DeviceSession>;
+          if (
+            parsed.role === "manager" ||
+            parsed.role === "member" ||
+            parsed.role === "crowd"
+          ) {
+            const nextSession: DeviceSession = {
+              role: parsed.role,
+              provisionedAt:
+                typeof parsed.provisionedAt === "number" ? parsed.provisionedAt : Date.now(),
+            };
+            setDeviceSession(nextSession);
+            setIsUnlocked(nextSession.role === "crowd");
+          }
         }
       } catch (error) {
         console.warn("Unable to hydrate workspace session", error);
@@ -26,18 +42,97 @@ export function useWorkspaceSession() {
     void hydrate();
   }, []);
 
-  const setActiveRole = async (role: Role | null) => {
-    setActiveRoleState(role);
-    if (role) {
-      await AsyncStorage.setItem(SESSION_KEY, role);
+  const persistSession = async (nextSession: DeviceSession | null) => {
+    if (!nextSession) {
+      await AsyncStorage.removeItem(SESSION_KEY);
       return;
     }
-    await AsyncStorage.removeItem(SESSION_KEY);
+
+    await AsyncStorage.setItem(SESSION_KEY, JSON.stringify(nextSession));
   };
+
+  const provisionRole = async (role: Role) => {
+    const nextSession: DeviceSession = {
+      role,
+      provisionedAt: Date.now(),
+    };
+
+    setDeviceSession(nextSession);
+    setIsUnlocked(true);
+    await persistSession(nextSession);
+  };
+
+  const clearDeviceSession = async () => {
+    setDeviceSession(null);
+    setIsUnlocked(false);
+    await persistSession(null);
+  };
+
+  const lockWorkspace = () => {
+    if (!deviceSession || deviceSession.role === "crowd") {
+      return;
+    }
+
+    setIsUnlocked(false);
+  };
+
+  const validatePasscode = (role: ProtectedRole, passcode: string, access: AccessSettings) => {
+    const expectedPasscode = role === "manager" ? access.managerPin : access.memberPin;
+    return passcode.trim() === expectedPasscode;
+  };
+
+  const unlockWorkspace = async (passcode: string, access: AccessSettings) => {
+    if (!deviceSession || deviceSession.role === "crowd") {
+      return false;
+    }
+
+    if (!validatePasscode(deviceSession.role, passcode, access)) {
+      return false;
+    }
+
+    setIsUnlocked(true);
+    return true;
+  };
+
+  const exitCrowdMode = async (managerPasscode: string, access: AccessSettings) => {
+    if (deviceSession?.role !== "crowd") {
+      return false;
+    }
+
+    if (!validatePasscode("manager", managerPasscode, access)) {
+      return false;
+    }
+
+    await clearDeviceSession();
+    return true;
+  };
+
+  let shellState: WorkspaceShellState = "hydrating";
+  let activeRole: Role | null = null;
+
+  if (hydrated) {
+    if (!deviceSession) {
+      shellState = "setup";
+    } else if (deviceSession.role === "crowd") {
+      shellState = "active";
+      activeRole = "crowd";
+    } else if (isUnlocked) {
+      shellState = "active";
+      activeRole = deviceSession.role;
+    } else {
+      shellState = "locked";
+    }
+  }
 
   return {
     activeRole,
+    clearDeviceSession,
+    deviceSession,
+    exitCrowdMode,
     hydrated,
-    setActiveRole,
+    lockWorkspace,
+    provisionRole,
+    shellState,
+    unlockWorkspace,
   };
 }

--- a/src/screens/CrowdView.tsx
+++ b/src/screens/CrowdView.tsx
@@ -24,9 +24,11 @@ export function CrowdView({
   activeShow,
   bandName,
   boostRequest,
+  crowdLabel,
   helpers,
   isTablet,
   links,
+  onRequestStaffAccess,
   addRequest,
   addSupportTip,
   songs,
@@ -36,9 +38,11 @@ export function CrowdView({
   activeShow: Show | null;
   bandName: string;
   boostRequest: (requestId: string) => void;
+  crowdLabel: string;
   helpers: CrowdHelpers;
   isTablet: boolean;
   links: BandLinks;
+  onRequestStaffAccess: () => void;
   addRequest: (payload: { requester: string; songId: string; note: string; tip: number }) => void;
   addSupportTip: (payload: { supporter: string; amount: number; note: string }) => void;
   songs: Song[];
@@ -63,15 +67,20 @@ export function CrowdView({
 
   return (
     <View style={styles.sectionStack}>
-      <View style={styles.sectionHeader}>
+      <Pressable
+        delayLongPress={3000}
+        onLongPress={onRequestStaffAccess}
+        style={styles.sectionHeader}
+      >
         <View>
           <Text style={styles.eyebrow}>Audience mode</Text>
-          <Text style={styles.sectionTitle}>Crowd workspace</Text>
+          <Text style={styles.sectionTitle}>{crowdLabel}</Text>
         </View>
         <Text style={styles.sectionCopy}>
-          This layout is built to breathe on a tablet, with request entry and support actions beside a live-updating queue.
+          This layout is built to breathe on a tablet, with request entry and support actions beside
+          a live-updating queue.
         </Text>
-      </View>
+      </Pressable>
 
       <SectionCard
         title={activeShow?.venue || bandName}

--- a/src/screens/LaunchScreen.tsx
+++ b/src/screens/LaunchScreen.tsx
@@ -32,10 +32,10 @@ const roleCopy: Record<
 
 export function LaunchScreen({
   access,
-  onEnterRole,
+  onProvisionRole,
 }: {
   access: AccessSettings;
-  onEnterRole: (role: Role) => void | Promise<void>;
+  onProvisionRole: (role: Role) => void | Promise<void>;
 }) {
   const [selectedRole, setSelectedRole] = useState<Role>("crowd");
   const [pin, setPin] = useState("");
@@ -62,23 +62,24 @@ export function LaunchScreen({
 
     setError("");
     setPin("");
-    await onEnterRole(selectedRole);
+    await onProvisionRole(selectedRole);
   };
 
   return (
     <View style={styles.sectionStack}>
       <View style={styles.sectionHeader}>
         <View>
-          <Text style={styles.eyebrow}>Device launch</Text>
-          <Text style={styles.sectionTitle}>Choose this device's job</Text>
+          <Text style={styles.eyebrow}>Device setup</Text>
+          <Text style={styles.sectionTitle}>Provision this device</Text>
         </View>
         <Text style={styles.sectionCopy}>
-          Crowd tablets stay open and simple. Manager and band-member modes require a local access
-          code so the backstage tools are not accidentally exposed on venue devices.
+          Choose whether this phone or tablet should behave like a manager device, a band-member
+          device, or a public crowd kiosk. Protected roles require a local passcode before the
+          session is provisioned.
         </Text>
       </View>
 
-      <SectionCard title="Workspace access" eyebrow="Local launch control">
+      <SectionCard title="Device roles" eyebrow="Local provisioning flow">
         <View style={styles.launchRoleGrid}>
           {(["manager", "member", "crowd"] as Role[]).map((role) => {
             const config = roleCopy[role];
@@ -126,8 +127,8 @@ export function LaunchScreen({
         <PrimaryButton
           label={
             selectedRole === "crowd"
-              ? `Enter ${access.crowdLabel || "crowd tablet"}`
-              : `Unlock ${selectedConfig.title}`
+              ? `Provision ${access.crowdLabel || "crowd tablet"}`
+              : `Provision ${selectedConfig.title}`
           }
           onPress={() => {
             void handleContinue();
@@ -136,8 +137,8 @@ export function LaunchScreen({
 
         <View style={styles.stackGap}>
           <Text style={styles.helperText}>
-            Stub passcodes are editable from the manager workspace. This is a local-only gate for
-            now, which gives us product shape before we add real authentication.
+            This stores a local device session only. Manager and member devices will still require
+            unlock on relaunch, which keeps the shell compatible with future real authentication.
           </Text>
         </View>
       </SectionCard>

--- a/src/screens/UnlockScreen.tsx
+++ b/src/screens/UnlockScreen.tsx
@@ -1,0 +1,84 @@
+import React, { useState } from "react";
+import { Text, View } from "react-native";
+
+import { GhostButton, PrimaryButton, SectionCard, TextInputField } from "../components/ui";
+import { appStyles as styles } from "../styles/appStyles";
+import { ProtectedRole } from "../types/stagehand";
+
+const roleCopy: Record<ProtectedRole, { title: string; description: string }> = {
+  manager: {
+    title: "Manager device",
+    description:
+      "Unlock the full backstage workspace for songs, shows, member management, and live controls.",
+  },
+  member: {
+    title: "Band-member device",
+    description:
+      "Unlock the active set, request queue, and payout snapshot without exposing manager controls.",
+  },
+};
+
+export function UnlockScreen({
+  role,
+  onUnlock,
+  onReprovision,
+}: {
+  role: ProtectedRole;
+  onUnlock: (passcode: string) => Promise<boolean>;
+  onReprovision: () => void;
+}) {
+  const [passcode, setPasscode] = useState("");
+  const [error, setError] = useState("");
+
+  const handleUnlock = async () => {
+    const succeeded = await onUnlock(passcode);
+    if (!succeeded) {
+      setError("That passcode does not match this device session.");
+      return;
+    }
+
+    setError("");
+    setPasscode("");
+  };
+
+  return (
+    <View style={styles.sectionStack}>
+      <View style={styles.sectionHeader}>
+        <View>
+          <Text style={styles.eyebrow}>Protected access</Text>
+          <Text style={styles.sectionTitle}>Unlock this device</Text>
+        </View>
+        <Text style={styles.sectionCopy}>
+          This device is already provisioned. Unlock it to continue into the protected workspace.
+        </Text>
+      </View>
+
+      <SectionCard title={roleCopy[role].title} eyebrow="Provisioned device session">
+        <Text style={styles.leadCopy}>{roleCopy[role].description}</Text>
+
+        <TextInputField
+          label="Passcode"
+          value={passcode}
+          keyboardType="numeric"
+          onChangeText={(text) => {
+            setPasscode(text);
+            if (error) {
+              setError("");
+            }
+          }}
+        />
+
+        {error ? <Text style={styles.errorText}>{error}</Text> : null}
+
+        <PrimaryButton
+          label={`Unlock ${roleCopy[role].title}`}
+          onPress={() => {
+            void handleUnlock();
+          }}
+        />
+
+        <GhostButton label="Reprovision this device" onPress={onReprovision} />
+      </SectionCard>
+    </View>
+  );
+}

--- a/src/styles/appStyles.ts
+++ b/src/styles/appStyles.ts
@@ -108,6 +108,12 @@ export const appStyles = StyleSheet.create({
   workspaceHeaderCopy: {
     flex: 1,
   },
+  workspaceActionGroup: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+    justifyContent: "flex-end",
+  },
   workspaceTitle: {
     color: colors.text,
     fontSize: 22,
@@ -436,6 +442,30 @@ export const appStyles = StyleSheet.create({
     color: colors.muted,
     fontSize: 13,
     lineHeight: 20,
+  },
+  modalBackdrop: {
+    flex: 1,
+    backgroundColor: "rgba(22, 30, 36, 0.54)",
+    justifyContent: "center",
+    padding: 24,
+  },
+  modalCard: {
+    backgroundColor: colors.card,
+    borderRadius: 28,
+    borderWidth: 1,
+    borderColor: colors.border,
+    padding: 20,
+    gap: 12,
+  },
+  modalTitle: {
+    color: colors.text,
+    fontSize: 24,
+    fontWeight: "800",
+  },
+  modalBody: {
+    color: colors.muted,
+    fontSize: 15,
+    lineHeight: 22,
   },
   linkCard: {
     borderRadius: 18,

--- a/src/types/stagehand.ts
+++ b/src/types/stagehand.ts
@@ -1,4 +1,10 @@
 export type Role = "manager" | "member" | "crowd";
+export type ProtectedRole = Exclude<Role, "crowd">;
+
+export type DeviceSession = {
+  role: Role;
+  provisionedAt: number;
+};
 
 export type SongEnergy = "Low" | "Mid" | "High";
 


### PR DESCRIPTION
## Summary
- replace the ad hoc launch gate with a real local device-session shell
- add setup, unlock, lock, and reprovision flows for manager/member devices
- add the hidden crowd kiosk exit path with manager verification
- document the local auth/session shell in the README

## Testing
- `npx tsc --noEmit`

Closes #15