### PR TITLE
Compact role mockups into dashboard layouts for #19

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -53,9 +53,8 @@ function App() {
             <Text style={styles.eyebrow}>Unified band operations</Text>
             <Text style={styles.heroTitle}>StageHand</Text>
             <Text style={styles.heroBody}>
-              One mobile app for the manager, the band, and the room. The crowd experience expands
-              into a tablet-first layout so request taking and tipping can live beside the stage or
-              merch table.
+              Manager, band, and crowd tools now aim for a tighter dashboard feel instead of long
+              stacked mockups.
             </Text>
           </View>
 

--- a/src/screens/CrowdView.tsx
+++ b/src/screens/CrowdView.tsx
@@ -1,8 +1,9 @@
 import React, { useEffect, useState } from "react";
-import { Linking, Pressable, Text, View } from "react-native";
+import { Linking, Pressable, ScrollView, Text, View } from "react-native";
 
 import {
   EmptyState,
+  MetricCard,
   PrimaryButton,
   RequestCard,
   RowCard,
@@ -19,6 +20,8 @@ type CrowdHelpers = {
   formatLink: (label: string, value: string) => string;
   songById: (songId: string) => Song | undefined;
 };
+
+type CrowdPanel = "request" | "support" | "queue";
 
 export function CrowdView({
   activeShow,
@@ -49,6 +52,7 @@ export function CrowdView({
   sortedRequests: RequestItem[];
   supportTips: SupportTip[];
 }) {
+  const [activePanel, setActivePanel] = useState<CrowdPanel>("request");
   const [requester, setRequester] = useState("");
   const [selectedSongId, setSelectedSongId] = useState(songs[0]?.id || "");
   const [requestNote, setRequestNote] = useState("");
@@ -77,8 +81,8 @@ export function CrowdView({
           <Text style={styles.sectionTitle}>{crowdLabel}</Text>
         </View>
         <Text style={styles.sectionCopy}>
-          This layout is built to breathe on a tablet, with request entry and support actions beside
-          a live-updating queue.
+          The crowd mockup now behaves more like a kiosk dashboard: quick action cards, shorter
+          queue visibility, and far less vertical wandering.
         </Text>
       </Pressable>
 
@@ -86,153 +90,200 @@ export function CrowdView({
         title={activeShow?.venue || bandName}
         eyebrow={activeShow ? helpers.formatDate(activeShow.date) : "No active show"}
       >
-        <Text style={styles.leadCopy}>
-          {activeShow
-            ? `${bandName} is playing ${activeShow.city}. Request a song, boost the queue, buy merch, or tip the band directly.`
-            : `${bandName} has not selected an active show yet, but support links and the catalog are still available.`}
-        </Text>
+        <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
+          <MetricCard
+            label="Now playing"
+            value={activeShow?.city || "Waiting"}
+            detail={activeShow ? bandName : "Show not activated yet"}
+          />
+          <MetricCard
+            label="Requests live"
+            value={`${sortedRequests.length}`}
+            detail="Songs in the room queue"
+          />
+          <MetricCard
+            label="Support tips"
+            value={`${supportTips.length}`}
+            detail="Direct support entries"
+          />
+        </View>
       </SectionCard>
 
+      {!isTablet ? (
+        <View style={styles.tabRow}>
+          {([
+            ["request", "Request"],
+            ["support", "Support"],
+            ["queue", "Queue"],
+          ] as [CrowdPanel, string][]).map(([panel, label]) => {
+            const active = activePanel === panel;
+            return (
+              <Pressable
+                key={panel}
+                onPress={() => setActivePanel(panel)}
+                style={[styles.tabPill, active && styles.tabPillActive]}
+              >
+                <Text style={[styles.tabPillText, active && styles.tabPillTextActive]}>{label}</Text>
+              </Pressable>
+            );
+          })}
+        </View>
+      ) : null}
+
       <View style={[styles.crowdColumns, isTablet && styles.crowdColumnsTablet]}>
-        <View style={styles.crowdLeftColumn}>
-          <SectionCard title="Request a song" eyebrow="Built for walk-up crowd use">
-            <TextInputField label="Your name" value={requester} onChangeText={setRequester} />
-            <Text style={styles.fieldLabel}>Song</Text>
-            <View style={styles.pillWrap}>
-              {songs.map((song) => (
-                <Pressable
-                  key={song.id}
-                  onPress={() => setSelectedSongId(song.id)}
-                  style={[
-                    styles.selectPill,
-                    selectedSongId === song.id && styles.selectPillActive,
-                  ]}
-                >
-                  <Text
-                    style={[
-                      styles.selectPillText,
-                      selectedSongId === song.id && styles.selectPillTextActive,
-                    ]}
-                  >
-                    {song.title}
-                  </Text>
-                </Pressable>
-              ))}
-            </View>
-            <TextInputField label="Message" value={requestNote} onChangeText={setRequestNote} />
-            <TextInputField
-              label="Tip amount"
-              value={tipAmount}
-              keyboardType="numeric"
-              onChangeText={setTipAmount}
-            />
-            <PrimaryButton
-              label="Send request"
-              onPress={() => {
-                if (!requester.trim() || !selectedSongId) {
-                  return;
-                }
-                addRequest({
-                  requester: requester.trim(),
-                  songId: selectedSongId,
-                  note: requestNote.trim(),
-                  tip: Number(tipAmount) || 0,
-                });
-                setRequester("");
-                setRequestNote("");
-                setTipAmount("5");
-              }}
-            />
-          </SectionCard>
-
-          <SectionCard title="Support the band" eyebrow="Fast tip jar and handoff links">
-            <TextInputField label="Your name" value={supporter} onChangeText={setSupporter} />
-            <TextInputField
-              label="Amount"
-              value={supportAmount}
-              keyboardType="numeric"
-              onChangeText={setSupportAmount}
-            />
-            <TextInputField label="Note" value={supportNote} onChangeText={setSupportNote} />
-            <PrimaryButton
-              label="Add support tip"
-              onPress={() => {
-                if (!supporter.trim()) {
-                  return;
-                }
-                addSupportTip({
-                  supporter: supporter.trim(),
-                  amount: Number(supportAmount) || 0,
-                  note: supportNote.trim(),
-                });
-                setSupporter("");
-                setSupportAmount("10");
-                setSupportNote("");
-              }}
-            />
-            <View style={styles.stackGap}>
-              {supportLinks.map((item) => (
-                <Pressable
-                  key={item.label}
-                  onPress={() => void Linking.openURL(helpers.formatLink(item.label, item.value))}
-                  style={styles.linkCard}
-                >
-                  <Text style={styles.linkCardTitle}>{item.label}</Text>
-                  <Text style={styles.linkCardValue}>{item.value}</Text>
-                </Pressable>
-              ))}
-            </View>
-          </SectionCard>
-        </View>
-
-        <View style={styles.crowdRightColumn}>
-          <SectionCard
-            title="Live request queue"
-            eyebrow={`${sortedRequests.length} songs competing right now`}
-          >
-            <View style={styles.stackGap}>
-              {sortedRequests.length ? (
-                sortedRequests.map((request) => {
-                  const song = helpers.songById(request.songId);
-                  if (!song) {
-                    return null;
+        {isTablet || activePanel === "request" ? (
+          <View style={styles.crowdLeftColumn}>
+            <SectionCard title="Request a song" eyebrow="Fast walk-up flow">
+              <TextInputField label="Your name" value={requester} onChangeText={setRequester} />
+              <Text style={styles.fieldLabel}>Song</Text>
+              <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                <View style={styles.pillWrap}>
+                  {songs.map((song) => (
+                    <Pressable
+                      key={song.id}
+                      onPress={() => setSelectedSongId(song.id)}
+                      style={[
+                        styles.selectPill,
+                        selectedSongId === song.id && styles.selectPillActive,
+                      ]}
+                    >
+                      <Text
+                        style={[
+                          styles.selectPillText,
+                          selectedSongId === song.id && styles.selectPillTextActive,
+                        ]}
+                      >
+                        {song.title}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </View>
+              </ScrollView>
+              <TextInputField label="Message" value={requestNote} onChangeText={setRequestNote} />
+              <TextInputField
+                label="Tip amount"
+                value={tipAmount}
+                keyboardType="numeric"
+                onChangeText={setTipAmount}
+              />
+              <PrimaryButton
+                label="Send request"
+                onPress={() => {
+                  if (!requester.trim() || !selectedSongId) {
+                    return;
                   }
+                  addRequest({
+                    requester: requester.trim(),
+                    songId: selectedSongId,
+                    note: requestNote.trim(),
+                    tip: Number(tipAmount) || 0,
+                  });
+                  setRequester("");
+                  setRequestNote("");
+                  setTipAmount("5");
+                }}
+              />
+            </SectionCard>
+          </View>
+        ) : null}
 
-                  return (
-                    <RequestCard
-                      key={request.id}
-                      title={song.title}
-                      subtitle={`${song.artist} · ${request.requester}`}
-                      note={request.note || "No note"}
-                      value={`${helpers.formatCurrency(request.tip)} · ${request.upvotes} boosts`}
-                      primaryLabel="Boost +$5"
-                      primaryAction={() => boostRequest(request.id)}
-                    />
-                  );
-                })
-              ) : (
-                <EmptyState label="The request queue is empty. Be the first one in." />
-              )}
-            </View>
-          </SectionCard>
+        {isTablet || activePanel === "support" ? (
+          <View style={styles.crowdLeftColumn}>
+            <SectionCard title="Support the band" eyebrow="Tip jar plus link handoff">
+              <TextInputField label="Your name" value={supporter} onChangeText={setSupporter} />
+              <TextInputField
+                label="Amount"
+                value={supportAmount}
+                keyboardType="numeric"
+                onChangeText={setSupportAmount}
+              />
+              <TextInputField label="Note" value={supportNote} onChangeText={setSupportNote} />
+              <PrimaryButton
+                label="Add support tip"
+                onPress={() => {
+                  if (!supporter.trim()) {
+                    return;
+                  }
+                  addSupportTip({
+                    supporter: supporter.trim(),
+                    amount: Number(supportAmount) || 0,
+                    note: supportNote.trim(),
+                  });
+                  setSupporter("");
+                  setSupportAmount("10");
+                  setSupportNote("");
+                }}
+              />
+              <View style={[styles.linkGrid, isTablet && styles.linkGridTablet]}>
+                {supportLinks.map((item) => (
+                  <Pressable
+                    key={item.label}
+                    onPress={() => void Linking.openURL(helpers.formatLink(item.label, item.value))}
+                    style={styles.linkCard}
+                  >
+                    <Text style={styles.linkCardTitle}>{item.label}</Text>
+                    <Text style={styles.linkCardValue}>{item.value}</Text>
+                  </Pressable>
+                ))}
+              </View>
+            </SectionCard>
+          </View>
+        ) : null}
 
-          <SectionCard title="Recent support" eyebrow={`${supportTips.length} direct tips logged`}>
-            <View style={styles.stackGap}>
-              {supportTips.length ? (
-                supportTips.map((tip) => (
-                  <RowCard
-                    key={tip.id}
-                    title={tip.supporter}
-                    subtitle={tip.note || "General support tip"}
-                    aside={<Text style={styles.moneyText}>{helpers.formatCurrency(tip.amount)}</Text>}
-                  />
-                ))
-              ) : (
-                <EmptyState label="No direct support tips yet." />
-              )}
-            </View>
-          </SectionCard>
-        </View>
+        {isTablet || activePanel === "queue" ? (
+          <View style={styles.crowdRightColumn}>
+            <SectionCard
+              title="Live request queue"
+              eyebrow={`${sortedRequests.length} songs competing right now`}
+            >
+              <ScrollView style={styles.embeddedScrollAreaTall}>
+                <View style={styles.stackGap}>
+                  {sortedRequests.length ? (
+                    sortedRequests.map((request) => {
+                      const song = helpers.songById(request.songId);
+                      if (!song) {
+                        return null;
+                      }
+
+                      return (
+                        <RequestCard
+                          key={request.id}
+                          title={song.title}
+                          subtitle={`${song.artist} · ${request.requester}`}
+                          note={request.note || "No note"}
+                          value={`${helpers.formatCurrency(request.tip)} · ${request.upvotes} boosts`}
+                          primaryLabel="Boost +$5"
+                          primaryAction={() => boostRequest(request.id)}
+                        />
+                      );
+                    })
+                  ) : (
+                    <EmptyState label="The request queue is empty. Be the first one in." />
+                  )}
+                </View>
+              </ScrollView>
+            </SectionCard>
+
+            <SectionCard title="Recent support" eyebrow={`${supportTips.length} direct tips logged`}>
+              <ScrollView style={styles.embeddedScrollArea}>
+                <View style={styles.stackGap}>
+                  {supportTips.length ? (
+                    supportTips.map((tip) => (
+                      <RowCard
+                        key={tip.id}
+                        title={tip.supporter}
+                        subtitle={tip.note || "General support tip"}
+                        aside={<Text style={styles.moneyText}>{helpers.formatCurrency(tip.amount)}</Text>}
+                      />
+                    ))
+                  ) : (
+                    <EmptyState label="No direct support tips yet." />
+                  )}
+                </View>
+              </ScrollView>
+            </SectionCard>
+          </View>
+        ) : null}
       </View>
     </View>
   );

--- a/src/screens/ManagerView.tsx
+++ b/src/screens/ManagerView.tsx
@@ -1,9 +1,10 @@
 import React, { useEffect, useState } from "react";
-import { Pressable, Text, TextInput, View } from "react-native";
+import { Pressable, ScrollView, Text, TextInput, useWindowDimensions, View } from "react-native";
 
 import {
   EmptyState,
   GhostButton,
+  MetricCard,
   PrimaryButton,
   RequestCard,
   RowCard,
@@ -39,6 +40,8 @@ type ManagerActions = {
   clearRequest: (requestId: string) => void;
 };
 
+type ManagerPanel = "configure" | "catalog" | "show" | "queue";
+
 export function ManagerView({
   activeShow,
   helpers,
@@ -56,6 +59,9 @@ export function ManagerView({
   totalTips: number;
   actions: ManagerActions;
 }) {
+  const { width } = useWindowDimensions();
+  const isTablet = width >= 980;
+  const [activePanel, setActivePanel] = useState<ManagerPanel>("show");
   const [profile, setProfile] = useState({
     bandName: state.bandName,
     merchStore: state.links.merchStore,
@@ -89,7 +95,7 @@ export function ManagerView({
       paypal: state.links.paypal,
     });
     setAccessDraft(state.access);
-  }, [state.bandName, state.links]);
+  }, [state.bandName, state.links, state.access]);
 
   useEffect(() => {
     if (!state.songs.find((song) => song.id === selectedSongId)) {
@@ -105,347 +111,455 @@ export function ManagerView({
           <Text style={styles.sectionTitle}>Manager workspace</Text>
         </View>
         <Text style={styles.sectionCopy}>
-          Edit the full operating model: songs, shows, members, links, lineups, and the live queue.
+          The manager mockup is now organized like a control dashboard: overview first, then one
+          focused operating panel at a time.
         </Text>
       </View>
 
-      <SectionCard title="Band profile" eyebrow="Links and payouts">
-        <TextInputField
-          label="Band name"
-          value={profile.bandName}
-          onChangeText={(text) => setProfile((current) => ({ ...current, bandName: text }))}
-        />
-        <TextInputField
-          label="Merch store"
-          value={profile.merchStore}
-          onChangeText={(text) => setProfile((current) => ({ ...current, merchStore: text }))}
-        />
-        <TextInputField
-          label="Show calendar"
-          value={profile.showCalendar}
-          onChangeText={(text) => setProfile((current) => ({ ...current, showCalendar: text }))}
-        />
-        <TextInputField
-          label="Venmo"
-          value={profile.venmo}
-          onChangeText={(text) => setProfile((current) => ({ ...current, venmo: text }))}
-        />
-        <TextInputField
-          label="Cash App"
-          value={profile.cashapp}
-          onChangeText={(text) => setProfile((current) => ({ ...current, cashapp: text }))}
-        />
-        <TextInputField
-          label="PayPal"
-          value={profile.paypal}
-          onChangeText={(text) => setProfile((current) => ({ ...current, paypal: text }))}
-        />
-        <PrimaryButton label="Save profile" onPress={() => actions.updateProfile(profile)} />
-      </SectionCard>
-
-      <SectionCard title="Access controls" eyebrow="Local workspace passcodes">
-        <TextInputField
-          label="Manager passcode"
-          value={accessDraft.managerPin}
-          keyboardType="numeric"
-          onChangeText={(text) => setAccessDraft((current) => ({ ...current, managerPin: text }))}
-        />
-        <TextInputField
-          label="Band member passcode"
-          value={accessDraft.memberPin}
-          keyboardType="numeric"
-          onChangeText={(text) => setAccessDraft((current) => ({ ...current, memberPin: text }))}
-        />
-        <TextInputField
-          label="Crowd device label"
-          value={accessDraft.crowdLabel}
-          onChangeText={(text) => setAccessDraft((current) => ({ ...current, crowdLabel: text }))}
-        />
-        <PrimaryButton
-          label="Save access settings"
-          onPress={() =>
-            actions.updateAccess({
-              managerPin: accessDraft.managerPin.trim() || state.access.managerPin,
-              memberPin: accessDraft.memberPin.trim() || state.access.memberPin,
-              crowdLabel: accessDraft.crowdLabel.trim() || state.access.crowdLabel,
-            })
-          }
-        />
-      </SectionCard>
-
-      <SectionCard title="Song catalog" eyebrow={`${state.songs.length} songs in rotation`}>
-        <TextInputField
-          label="Song title"
-          value={songDraft.title}
-          onChangeText={(text) => setSongDraft((current) => ({ ...current, title: text }))}
-        />
-        <TextInputField
-          label="Original artist or note"
-          value={songDraft.artist}
-          onChangeText={(text) => setSongDraft((current) => ({ ...current, artist: text }))}
-        />
-        <TextInputField
-          label="Energy"
-          value={songDraft.energy}
-          onChangeText={(text) =>
-            setSongDraft((current) => ({ ...current, energy: helpers.normalizeEnergy(text) }))
-          }
-        />
-        <PrimaryButton
-          label="Add song"
-          onPress={() => {
-            if (!songDraft.title.trim() || !songDraft.artist.trim()) {
-              return;
-            }
-            actions.addSong({
-              title: songDraft.title.trim(),
-              artist: songDraft.artist.trim(),
-              energy: songDraft.energy,
-            });
-            setSongDraft({ title: "", artist: "", energy: "Mid" });
-          }}
-        />
-        <View style={styles.stackGap}>
-          {state.songs.map((song) => (
-            <RowCard
-              key={song.id}
-              title={song.title}
-              subtitle={`${song.artist} · ${song.energy} energy`}
-              aside={<GhostButton label="Remove" onPress={() => actions.removeSong(song.id)} />}
-            />
-          ))}
+      <SectionCard
+        title={activeShow?.venue || state.bandName}
+        eyebrow={activeShow ? `Active show · ${helpers.formatDate(activeShow.date)}` : "Band overview"}
+      >
+        <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
+          <MetricCard
+            label="Queued requests"
+            value={`${sortedRequests.length}`}
+            detail="Live demand to manage"
+          />
+          <MetricCard
+            label="Tonight's tips"
+            value={helpers.formatCurrency(totalTips)}
+            detail="Request boosts plus support"
+          />
+          <MetricCard
+            label="Lineup ready"
+            value={`${activeShow?.lineup.length || 0}`}
+            detail={activeShow ? `${activeShow.city}` : "No active show"}
+          />
         </View>
       </SectionCard>
 
-      <SectionCard
-        title="Band members"
-        eyebrow={`${state.members.length} members`}
-        sideLabel={splitTotal === 100 ? "Splits total 100%" : `Splits total ${splitTotal}%`}
-        sideTone={splitTotal === 100 ? "good" : "warning"}
-      >
-        <TextInputField
-          label="Member name"
-          value={memberDraft.name}
-          onChangeText={(text) => setMemberDraft((current) => ({ ...current, name: text }))}
-        />
-        <TextInputField
-          label="Role"
-          value={memberDraft.role}
-          onChangeText={(text) => setMemberDraft((current) => ({ ...current, role: text }))}
-        />
-        <TextInputField
-          label="Tip allocation %"
-          value={memberDraft.allocation}
-          keyboardType="numeric"
-          onChangeText={(text) =>
-            setMemberDraft((current) => ({ ...current, allocation: text }))
-          }
-        />
-        <PrimaryButton
-          label="Add member"
-          onPress={() => {
-            if (!memberDraft.name.trim() || !memberDraft.role.trim()) {
-              return;
-            }
-            actions.addMember({
-              name: memberDraft.name.trim(),
-              role: memberDraft.role.trim(),
-              allocation: Number(memberDraft.allocation) || 0,
-            });
-            setMemberDraft({ name: "", role: "", allocation: "25" });
-          }}
-        />
-        <View style={styles.stackGap}>
-          {state.members.map((member) => (
-            <View key={member.id} style={styles.rowCard}>
-              <View style={styles.rowMeta}>
-                <Text style={styles.rowTitle}>{member.name}</Text>
-                <Text style={styles.rowSubtitle}>{member.role}</Text>
-              </View>
-              <View style={styles.rowAside}>
-                <TextInput
-                  style={[styles.input, styles.inlineAllocation]}
-                  value={String(member.allocation)}
-                  keyboardType="numeric"
-                  onChangeText={(text) =>
-                    actions.updateMemberAllocation(member.id, Number(text) || 0)
+      <View style={styles.tabRow}>
+        {([
+          ["show", "Show Ops"],
+          ["queue", "Queue"],
+          ["catalog", "Catalog"],
+          ["configure", "Config"],
+        ] as [ManagerPanel, string][]).map(([panel, label]) => {
+          const active = activePanel === panel;
+          return (
+            <Pressable
+              key={panel}
+              onPress={() => setActivePanel(panel)}
+              style={[styles.tabPill, active && styles.tabPillActive]}
+            >
+              <Text style={[styles.tabPillText, active && styles.tabPillTextActive]}>{label}</Text>
+            </Pressable>
+          );
+        })}
+      </View>
+
+      {activePanel === "configure" ? (
+        <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
+          <View style={styles.dashboardColumn}>
+            <SectionCard title="Band profile" eyebrow="Links and support handoff">
+              <TextInputField
+                label="Band name"
+                value={profile.bandName}
+                onChangeText={(text) => setProfile((current) => ({ ...current, bandName: text }))}
+              />
+              <TextInputField
+                label="Merch store"
+                value={profile.merchStore}
+                onChangeText={(text) => setProfile((current) => ({ ...current, merchStore: text }))}
+              />
+              <TextInputField
+                label="Show calendar"
+                value={profile.showCalendar}
+                onChangeText={(text) =>
+                  setProfile((current) => ({ ...current, showCalendar: text }))
+                }
+              />
+              <TextInputField
+                label="Venmo"
+                value={profile.venmo}
+                onChangeText={(text) => setProfile((current) => ({ ...current, venmo: text }))}
+              />
+              <TextInputField
+                label="Cash App"
+                value={profile.cashapp}
+                onChangeText={(text) => setProfile((current) => ({ ...current, cashapp: text }))}
+              />
+              <TextInputField
+                label="PayPal"
+                value={profile.paypal}
+                onChangeText={(text) => setProfile((current) => ({ ...current, paypal: text }))}
+              />
+              <PrimaryButton label="Save profile" onPress={() => actions.updateProfile(profile)} />
+            </SectionCard>
+          </View>
+
+          <View style={styles.dashboardColumn}>
+            <SectionCard
+              title="Access controls"
+              eyebrow="Local manager, member, and crowd device settings"
+            >
+              <TextInputField
+                label="Manager passcode"
+                value={accessDraft.managerPin}
+                keyboardType="numeric"
+                onChangeText={(text) =>
+                  setAccessDraft((current) => ({ ...current, managerPin: text }))
+                }
+              />
+              <TextInputField
+                label="Band member passcode"
+                value={accessDraft.memberPin}
+                keyboardType="numeric"
+                onChangeText={(text) =>
+                  setAccessDraft((current) => ({ ...current, memberPin: text }))
+                }
+              />
+              <TextInputField
+                label="Crowd device label"
+                value={accessDraft.crowdLabel}
+                onChangeText={(text) =>
+                  setAccessDraft((current) => ({ ...current, crowdLabel: text }))
+                }
+              />
+              <PrimaryButton
+                label="Save access settings"
+                onPress={() =>
+                  actions.updateAccess({
+                    managerPin: accessDraft.managerPin.trim() || state.access.managerPin,
+                    memberPin: accessDraft.memberPin.trim() || state.access.memberPin,
+                    crowdLabel: accessDraft.crowdLabel.trim() || state.access.crowdLabel,
+                  })
+                }
+              />
+            </SectionCard>
+          </View>
+        </View>
+      ) : null}
+
+      {activePanel === "catalog" ? (
+        <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
+          <View style={styles.dashboardColumn}>
+            <SectionCard title="Song catalog" eyebrow={`${state.songs.length} songs in rotation`}>
+              <TextInputField
+                label="Song title"
+                value={songDraft.title}
+                onChangeText={(text) => setSongDraft((current) => ({ ...current, title: text }))}
+              />
+              <TextInputField
+                label="Original artist or note"
+                value={songDraft.artist}
+                onChangeText={(text) => setSongDraft((current) => ({ ...current, artist: text }))}
+              />
+              <TextInputField
+                label="Energy"
+                value={songDraft.energy}
+                onChangeText={(text) =>
+                  setSongDraft((current) => ({
+                    ...current,
+                    energy: helpers.normalizeEnergy(text),
+                  }))
+                }
+              />
+              <PrimaryButton
+                label="Add song"
+                onPress={() => {
+                  if (!songDraft.title.trim() || !songDraft.artist.trim()) {
+                    return;
                   }
-                />
-                <GhostButton label="Remove" onPress={() => actions.removeMember(member.id)} />
-              </View>
-            </View>
-          ))}
+                  actions.addSong({
+                    title: songDraft.title.trim(),
+                    artist: songDraft.artist.trim(),
+                    energy: songDraft.energy,
+                  });
+                  setSongDraft({ title: "", artist: "", energy: "Mid" });
+                }}
+              />
+              <ScrollView style={styles.embeddedScrollArea}>
+                <View style={styles.stackGap}>
+                  {state.songs.map((song) => (
+                    <RowCard
+                      key={song.id}
+                      title={song.title}
+                      subtitle={`${song.artist} · ${song.energy} energy`}
+                      aside={<GhostButton label="Remove" onPress={() => actions.removeSong(song.id)} />}
+                    />
+                  ))}
+                </View>
+              </ScrollView>
+            </SectionCard>
+          </View>
+
+          <View style={styles.dashboardColumn}>
+            <SectionCard
+              title="Band members"
+              eyebrow={`${state.members.length} active members`}
+              sideLabel={splitTotal === 100 ? "Splits total 100%" : `Splits total ${splitTotal}%`}
+              sideTone={splitTotal === 100 ? "good" : "warning"}
+            >
+              <TextInputField
+                label="Member name"
+                value={memberDraft.name}
+                onChangeText={(text) => setMemberDraft((current) => ({ ...current, name: text }))}
+              />
+              <TextInputField
+                label="Role"
+                value={memberDraft.role}
+                onChangeText={(text) => setMemberDraft((current) => ({ ...current, role: text }))}
+              />
+              <TextInputField
+                label="Tip allocation %"
+                value={memberDraft.allocation}
+                keyboardType="numeric"
+                onChangeText={(text) =>
+                  setMemberDraft((current) => ({ ...current, allocation: text }))
+                }
+              />
+              <PrimaryButton
+                label="Add member"
+                onPress={() => {
+                  if (!memberDraft.name.trim() || !memberDraft.role.trim()) {
+                    return;
+                  }
+                  actions.addMember({
+                    name: memberDraft.name.trim(),
+                    role: memberDraft.role.trim(),
+                    allocation: Number(memberDraft.allocation) || 0,
+                  });
+                  setMemberDraft({ name: "", role: "", allocation: "25" });
+                }}
+              />
+              <ScrollView style={styles.embeddedScrollArea}>
+                <View style={styles.stackGap}>
+                  {state.members.map((member) => (
+                    <View key={member.id} style={styles.rowCard}>
+                      <View style={styles.rowMeta}>
+                        <Text style={styles.rowTitle}>{member.name}</Text>
+                        <Text style={styles.rowSubtitle}>{member.role}</Text>
+                      </View>
+                      <View style={styles.rowAside}>
+                        <TextInput
+                          style={[styles.input, styles.inlineAllocation]}
+                          value={String(member.allocation)}
+                          keyboardType="numeric"
+                          onChangeText={(text) =>
+                            actions.updateMemberAllocation(member.id, Number(text) || 0)
+                          }
+                        />
+                        <GhostButton
+                          label="Remove"
+                          onPress={() => actions.removeMember(member.id)}
+                        />
+                      </View>
+                    </View>
+                  ))}
+                </View>
+              </ScrollView>
+            </SectionCard>
+          </View>
         </View>
-      </SectionCard>
+      ) : null}
 
-      <SectionCard
-        title="Shows and set lists"
-        eyebrow={activeShow ? `Active show · ${activeShow.venue}` : "No active show"}
-      >
-        <TextInputField
-          label="Show date"
-          value={showDraft.date}
-          onChangeText={(text) => setShowDraft((current) => ({ ...current, date: text }))}
-        />
-        <TextInputField
-          label="Venue"
-          value={showDraft.venue}
-          onChangeText={(text) => setShowDraft((current) => ({ ...current, venue: text }))}
-        />
-        <TextInputField
-          label="City"
-          value={showDraft.city}
-          onChangeText={(text) => setShowDraft((current) => ({ ...current, city: text }))}
-        />
-        <TextInputField
-          label="Notes"
-          value={showDraft.notes}
-          onChangeText={(text) => setShowDraft((current) => ({ ...current, notes: text }))}
-        />
-        <PrimaryButton
-          label="Add show"
-          onPress={() => {
-            if (!showDraft.venue.trim() || !showDraft.city.trim()) {
-              return;
-            }
-            actions.addShow({
-              date: showDraft.date.trim() || nextFriday(),
-              venue: showDraft.venue.trim(),
-              city: showDraft.city.trim(),
-              notes: showDraft.notes.trim(),
-            });
-            setShowDraft({ date: nextFriday(), venue: "", city: "", notes: "" });
-          }}
-        />
+      {activePanel === "show" ? (
+        <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
+          <View style={styles.dashboardColumn}>
+            <SectionCard
+              title="Shows"
+              eyebrow={activeShow ? `Active show · ${activeShow.venue}` : "No active show"}
+            >
+              <TextInputField
+                label="Show date"
+                value={showDraft.date}
+                onChangeText={(text) => setShowDraft((current) => ({ ...current, date: text }))}
+              />
+              <TextInputField
+                label="Venue"
+                value={showDraft.venue}
+                onChangeText={(text) => setShowDraft((current) => ({ ...current, venue: text }))}
+              />
+              <TextInputField
+                label="City"
+                value={showDraft.city}
+                onChangeText={(text) => setShowDraft((current) => ({ ...current, city: text }))}
+              />
+              <TextInputField
+                label="Notes"
+                value={showDraft.notes}
+                onChangeText={(text) => setShowDraft((current) => ({ ...current, notes: text }))}
+              />
+              <PrimaryButton
+                label="Add show"
+                onPress={() => {
+                  if (!showDraft.venue.trim() || !showDraft.city.trim()) {
+                    return;
+                  }
+                  actions.addShow({
+                    date: showDraft.date.trim() || nextFriday(),
+                    venue: showDraft.venue.trim(),
+                    city: showDraft.city.trim(),
+                    notes: showDraft.notes.trim(),
+                  });
+                  setShowDraft({ date: nextFriday(), venue: "", city: "", notes: "" });
+                }}
+              />
+              <ScrollView style={styles.embeddedScrollArea}>
+                <View style={styles.stackGap}>
+                  {state.shows.map((show) => (
+                    <View key={show.id} style={styles.rowCard}>
+                      <View style={styles.rowMeta}>
+                        <Text style={styles.rowTitle}>{show.venue}</Text>
+                        <Text style={styles.rowSubtitle}>
+                          {helpers.formatDate(show.date)} · {show.city}
+                        </Text>
+                        <Text style={styles.rowSubtitle}>{show.notes || "No notes yet"}</Text>
+                      </View>
+                      <View style={styles.rowAside}>
+                        <GhostButton
+                          label={show.id === state.activeShowId ? "Active" : "Make active"}
+                          onPress={() => actions.setActiveShow(show.id)}
+                        />
+                        <GhostButton label="Remove" onPress={() => actions.removeShow(show.id)} />
+                      </View>
+                    </View>
+                  ))}
+                </View>
+              </ScrollView>
+            </SectionCard>
+          </View>
 
-        <View style={styles.stackGap}>
-          {state.shows.map((show) => (
-            <View key={show.id} style={styles.rowCard}>
-              <View style={styles.rowMeta}>
-                <Text style={styles.rowTitle}>{show.venue}</Text>
-                <Text style={styles.rowSubtitle}>
-                  {helpers.formatDate(show.date)} · {show.city}
-                </Text>
-                <Text style={styles.rowSubtitle}>{show.notes || "No notes yet"}</Text>
-              </View>
-              <View style={styles.rowAside}>
-                <GhostButton
-                  label={show.id === state.activeShowId ? "Active" : "Make active"}
-                  onPress={() => actions.setActiveShow(show.id)}
-                />
-                <GhostButton label="Remove" onPress={() => actions.removeShow(show.id)} />
-              </View>
-            </View>
-          ))}
+          <View style={styles.dashboardColumn}>
+            <SectionCard title="Active show ops" eyebrow={activeShow ? activeShow.city : "Assign a show"}>
+              {activeShow ? (
+                <>
+                  <Text style={styles.subheading}>Lineup</Text>
+                  <View style={styles.pillWrap}>
+                    {state.members.map((member) => {
+                      const active = activeShow.lineup.includes(member.id);
+                      return (
+                        <Pressable
+                          key={member.id}
+                          onPress={() => actions.toggleLineupMember(member.id)}
+                          style={[styles.togglePill, active && styles.togglePillActive]}
+                        >
+                          <Text
+                            style={[styles.togglePillText, active && styles.togglePillTextActive]}
+                          >
+                            {member.name}
+                          </Text>
+                        </Pressable>
+                      );
+                    })}
+                  </View>
+
+                  <Text style={styles.subheading}>Set list builder</Text>
+                  <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                    <View style={styles.pillWrap}>
+                      {state.songs.map((song) => (
+                        <Pressable
+                          key={song.id}
+                          onPress={() => setSelectedSongId(song.id)}
+                          style={[
+                            styles.selectPill,
+                            selectedSongId === song.id && styles.selectPillActive,
+                          ]}
+                        >
+                          <Text
+                            style={[
+                              styles.selectPillText,
+                              selectedSongId === song.id && styles.selectPillTextActive,
+                            ]}
+                          >
+                            {song.title}
+                          </Text>
+                        </Pressable>
+                      ))}
+                    </View>
+                  </ScrollView>
+                  <PrimaryButton
+                    label="Add selected song to set"
+                    onPress={() => selectedSongId && actions.addSongToSetList(selectedSongId)}
+                  />
+
+                  <ScrollView style={styles.embeddedScrollArea}>
+                    <View style={styles.stackGap}>
+                      {activeShow.setList.length ? (
+                        activeShow.setList.map((songId, index) => {
+                          const song = helpers.songById(songId);
+                          if (!song) {
+                            return null;
+                          }
+                          return (
+                            <RowCard
+                              key={`${songId}-${index}`}
+                              title={`${index + 1}. ${song.title}`}
+                              subtitle={`${song.artist} · ${song.energy} energy`}
+                              aside={
+                                <GhostButton
+                                  label="Remove"
+                                  onPress={() => actions.removeSongFromSetList(songId)}
+                                />
+                              }
+                            />
+                          );
+                        })
+                      ) : (
+                        <EmptyState label="No songs attached to the active show yet." />
+                      )}
+                    </View>
+                  </ScrollView>
+                </>
+              ) : (
+                <EmptyState label="Create or activate a show to assign lineup and set list." />
+              )}
+            </SectionCard>
+          </View>
         </View>
+      ) : null}
 
-        {activeShow ? (
-          <>
-            <Text style={styles.subheading}>Lineup for active show</Text>
-            <View style={styles.pillWrap}>
-              {state.members.map((member) => {
-                const active = activeShow.lineup.includes(member.id);
-                return (
-                  <Pressable
-                    key={member.id}
-                    onPress={() => actions.toggleLineupMember(member.id)}
-                    style={[styles.togglePill, active && styles.togglePillActive]}
-                  >
-                    <Text style={[styles.togglePillText, active && styles.togglePillTextActive]}>
-                      {member.name}
-                    </Text>
-                  </Pressable>
-                );
-              })}
-            </View>
-
-            <Text style={styles.subheading}>Attach songs to set list</Text>
-            <View style={styles.pillWrap}>
-              {state.songs.map((song) => (
-                <Pressable
-                  key={song.id}
-                  onPress={() => setSelectedSongId(song.id)}
-                  style={[
-                    styles.selectPill,
-                    selectedSongId === song.id && styles.selectPillActive,
-                  ]}
-                >
-                  <Text
-                    style={[
-                      styles.selectPillText,
-                      selectedSongId === song.id && styles.selectPillTextActive,
-                    ]}
-                  >
-                    {song.title}
-                  </Text>
-                </Pressable>
-              ))}
-            </View>
-            <PrimaryButton
-              label="Add selected song to set"
-              onPress={() => selectedSongId && actions.addSongToSetList(selectedSongId)}
-            />
-
+      {activePanel === "queue" ? (
+        <SectionCard
+          title="Live queue"
+          eyebrow={`${helpers.formatCurrency(totalTips)} total tipped tonight`}
+        >
+          <Text style={styles.compactNote}>
+            Queue moderation now lives in its own focused panel so the mockup reads more like a live
+            console than a scrolling document.
+          </Text>
+          <ScrollView style={styles.embeddedScrollAreaTall}>
             <View style={styles.stackGap}>
-              {activeShow.setList.length ? (
-                activeShow.setList.map((songId, index) => {
-                  const song = helpers.songById(songId);
+              {sortedRequests.length ? (
+                sortedRequests.map((request) => {
+                  const song = helpers.songById(request.songId);
                   if (!song) {
                     return null;
                   }
+
                   return (
-                    <RowCard
-                      key={`${songId}-${index}`}
-                      title={`${index + 1}. ${song.title}`}
-                      subtitle={`${song.artist} · ${song.energy} energy`}
-                      aside={
-                        <GhostButton
-                          label="Remove"
-                          onPress={() => actions.removeSongFromSetList(songId)}
-                        />
-                      }
+                    <RequestCard
+                      key={request.id}
+                      title={song.title}
+                      subtitle={`${song.artist} · ${request.requester}`}
+                      note={request.note || "No note"}
+                      value={`${helpers.formatCurrency(request.tip)} · ${request.upvotes} boosts`}
+                      primaryLabel="Boost +$5"
+                      primaryAction={() => actions.boostRequest(request.id)}
+                      secondaryLabel="Clear"
+                      secondaryAction={() => actions.clearRequest(request.id)}
                     />
                   );
                 })
               ) : (
-                <EmptyState label="No songs attached to the active show yet." />
+                <EmptyState label="No requests in the queue yet." />
               )}
             </View>
-          </>
-        ) : null}
-      </SectionCard>
-
-      <SectionCard
-        title="Live queue"
-        eyebrow={`${helpers.formatCurrency(totalTips)} total tipped tonight`}
-      >
-        <View style={styles.stackGap}>
-          {sortedRequests.length ? (
-            sortedRequests.map((request) => {
-              const song = helpers.songById(request.songId);
-              if (!song) {
-                return null;
-              }
-
-              return (
-                <RequestCard
-                  key={request.id}
-                  title={song.title}
-                  subtitle={`${song.artist} · ${request.requester}`}
-                  note={request.note || "No note"}
-                  value={`${helpers.formatCurrency(request.tip)} · ${request.upvotes} boosts`}
-                  primaryLabel="Boost +$5"
-                  primaryAction={() => actions.boostRequest(request.id)}
-                  secondaryLabel="Clear"
-                  secondaryAction={() => actions.clearRequest(request.id)}
-                />
-              );
-            })
-          ) : (
-            <EmptyState label="No requests in the queue yet." />
-          )}
-        </View>
-      </SectionCard>
+          </ScrollView>
+        </SectionCard>
+      ) : null}
     </View>
   );
 }

--- a/src/screens/MemberView.tsx
+++ b/src/screens/MemberView.tsx
@@ -1,7 +1,7 @@
 import React from "react";
-import { Text, View } from "react-native";
+import { ScrollView, Text, useWindowDimensions, View } from "react-native";
 
-import { EmptyState, RequestCard, RowCard, SectionCard } from "../components/ui";
+import { EmptyState, MetricCard, RequestCard, RowCard, SectionCard } from "../components/ui";
 import { appStyles as styles } from "../styles/appStyles";
 import { Member, RequestItem, Show, Song, StageHandState } from "../types/stagehand";
 
@@ -25,6 +25,14 @@ export function MemberView({
   state: StageHandState;
   totalTips: number;
 }) {
+  const { width } = useWindowDimensions();
+  const isTablet = width >= 900;
+  const visibleMembers = activeShow
+    ? activeShow.lineup
+        .map((memberId) => helpers.memberById(memberId))
+        .filter((member): member is Member => Boolean(member))
+    : state.members;
+
   return (
     <View style={styles.sectionStack}>
       <View style={styles.sectionHeader}>
@@ -33,7 +41,8 @@ export function MemberView({
           <Text style={styles.sectionTitle}>Band member workspace</Text>
         </View>
         <Text style={styles.sectionCopy}>
-          Keep the next show, the live queue, and payout expectations visible during the set.
+          The member view is now treated like a stage monitor: immediate context on top, then set,
+          queue, and payout panels in a compact grid.
         </Text>
       </View>
 
@@ -41,99 +50,125 @@ export function MemberView({
         title={activeShow?.venue || "No active show"}
         eyebrow={activeShow ? helpers.formatDate(activeShow.date) : "Schedule pending"}
       >
-        <Text style={styles.leadCopy}>
-          {activeShow
-            ? `${activeShow.city} · ${activeShow.notes || "No notes"}`
-            : "Create an active show in manager mode to populate this view."}
-        </Text>
-        <View style={styles.pillWrap}>
-          {activeShow?.lineup.length ? (
-            activeShow.lineup.map((memberId) => {
-              const member = helpers.memberById(memberId);
-              if (!member) {
-                return null;
-              }
-              return (
-                <View key={member.id} style={styles.personPill}>
-                  <Text style={styles.personPillTitle}>{member.name}</Text>
-                  <Text style={styles.personPillSubtitle}>{member.role}</Text>
-                </View>
-              );
-            })
-          ) : (
-            <EmptyState label="No lineup assigned yet." />
-          )}
+        <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
+          <MetricCard
+            label="Current city"
+            value={activeShow?.city || "TBD"}
+            detail={activeShow?.notes || "No show notes"}
+          />
+          <MetricCard
+            label="Set songs"
+            value={`${activeShow?.setList.length || 0}`}
+            detail="Songs queued for the set"
+          />
+          <MetricCard
+            label="Tips tracked"
+            value={helpers.formatCurrency(totalTips)}
+            detail={`${sortedRequests.length} request entries`}
+          />
         </View>
       </SectionCard>
 
-      <SectionCard
-        title="Set list"
-        eyebrow={activeShow?.setList.length ? `${activeShow.setList.length} songs queued` : "No songs attached"}
-      >
-        <View style={styles.stackGap}>
-          {activeShow?.setList.length ? (
-            activeShow.setList.map((songId, index) => {
-              const song = helpers.songById(songId);
-              if (!song) {
-                return null;
-              }
-              return (
-                <RowCard
-                  key={`${songId}-${index}`}
-                  title={`${index + 1}. ${song.title}`}
-                  subtitle={`${song.artist} · ${song.energy} energy`}
-                />
-              );
-            })
-          ) : (
-            <EmptyState label="No set list available yet." />
-          )}
-        </View>
-      </SectionCard>
+      <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
+        <View style={styles.dashboardColumn}>
+          <SectionCard
+            title="Set list"
+            eyebrow={
+              activeShow?.setList.length ? `${activeShow.setList.length} songs queued` : "No songs attached"
+            }
+          >
+            <ScrollView style={styles.embeddedScrollArea}>
+              <View style={styles.stackGap}>
+                {activeShow?.setList.length ? (
+                  activeShow.setList.map((songId, index) => {
+                    const song = helpers.songById(songId);
+                    if (!song) {
+                      return null;
+                    }
+                    return (
+                      <RowCard
+                        key={`${songId}-${index}`}
+                        title={`${index + 1}. ${song.title}`}
+                        subtitle={`${song.artist} · ${song.energy} energy`}
+                      />
+                    );
+                  })
+                ) : (
+                  <EmptyState label="No set list available yet." />
+                )}
+              </View>
+            </ScrollView>
+          </SectionCard>
 
-      <SectionCard
-        title="Tip breakdown"
-        eyebrow={`${helpers.formatCurrency(totalTips)} across requests and support`}
-      >
-        <View style={styles.stackGap}>
-          {state.members.map((member) => (
-            <RowCard
-              key={member.id}
-              title={member.name}
-              subtitle={`${member.role} · ${member.allocation}% split`}
-              aside={
-                <Text style={styles.moneyText}>
-                  {helpers.formatCurrency(totalTips * (member.allocation / 100))}
-                </Text>
-              }
-            />
-          ))}
+          <SectionCard
+            title="Lineup"
+            eyebrow={visibleMembers.length ? `${visibleMembers.length} players on this show` : "No lineup assigned"}
+          >
+            <View style={styles.pillWrap}>
+              {visibleMembers.length ? (
+                visibleMembers.map((member) => (
+                  <View key={member.id} style={styles.personPill}>
+                    <Text style={styles.personPillTitle}>{member.name}</Text>
+                    <Text style={styles.personPillSubtitle}>{member.role}</Text>
+                  </View>
+                ))
+              ) : (
+                <EmptyState label="No lineup assigned yet." />
+              )}
+            </View>
+          </SectionCard>
         </View>
-      </SectionCard>
 
-      <SectionCard title="Request queue" eyebrow={`${sortedRequests.length} requests waiting`}>
-        <View style={styles.stackGap}>
-          {sortedRequests.length ? (
-            sortedRequests.map((request) => {
-              const song = helpers.songById(request.songId);
-              if (!song) {
-                return null;
-              }
-              return (
-                <RequestCard
-                  key={request.id}
-                  title={song.title}
-                  subtitle={`${song.artist} · ${request.requester}`}
-                  note={request.note || "No note"}
-                  value={`${helpers.formatCurrency(request.tip)} · ${request.upvotes} boosts`}
-                />
-              );
-            })
-          ) : (
-            <EmptyState label="No live requests right now." />
-          )}
+        <View style={styles.dashboardColumn}>
+          <SectionCard title="Request queue" eyebrow={`${sortedRequests.length} requests waiting`}>
+            <ScrollView style={styles.embeddedScrollArea}>
+              <View style={styles.stackGap}>
+                {sortedRequests.length ? (
+                  sortedRequests.map((request) => {
+                    const song = helpers.songById(request.songId);
+                    if (!song) {
+                      return null;
+                    }
+                    return (
+                      <RequestCard
+                        key={request.id}
+                        title={song.title}
+                        subtitle={`${song.artist} · ${request.requester}`}
+                        note={request.note || "No note"}
+                        value={`${helpers.formatCurrency(request.tip)} · ${request.upvotes} boosts`}
+                      />
+                    );
+                  })
+                ) : (
+                  <EmptyState label="No live requests right now." />
+                )}
+              </View>
+            </ScrollView>
+          </SectionCard>
+
+          <SectionCard
+            title="Payout snapshot"
+            eyebrow={`${helpers.formatCurrency(totalTips)} across requests and support`}
+          >
+            <ScrollView style={styles.embeddedScrollArea}>
+              <View style={styles.stackGap}>
+                {state.members.map((member) => (
+                  <RowCard
+                    key={member.id}
+                    title={member.name}
+                    subtitle={`${member.role} · ${member.allocation}% split`}
+                    aside={
+                      <Text style={styles.moneyText}>
+                        {helpers.formatCurrency(totalTips * (member.allocation / 100))}
+                      </Text>
+                    }
+                  />
+                ))}
+              </View>
+            </ScrollView>
+          </SectionCard>
         </View>
-      </SectionCard>
+      </View>
     </View>
   );
 }

--- a/src/styles/appStyles.ts
+++ b/src/styles/appStyles.ts
@@ -43,6 +43,12 @@ export const appStyles = StyleSheet.create({
   heroStatsTablet: {
     flexDirection: "row",
   },
+  metricGrid: {
+    gap: 12,
+  },
+  metricGridTablet: {
+    flexDirection: "row",
+  },
   metricCard: {
     flex: 1,
     backgroundColor: colors.card,
@@ -180,6 +186,42 @@ export const appStyles = StyleSheet.create({
   },
   stackGap: {
     gap: 12,
+  },
+  dashboardColumns: {
+    gap: 16,
+  },
+  dashboardColumnsTablet: {
+    flexDirection: "row",
+    alignItems: "flex-start",
+  },
+  dashboardColumn: {
+    flex: 1,
+    gap: 16,
+  },
+  tabRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 10,
+  },
+  tabPill: {
+    borderRadius: 999,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.panel,
+  },
+  tabPillActive: {
+    backgroundColor: colors.text,
+    borderColor: colors.text,
+  },
+  tabPillText: {
+    color: colors.text,
+    fontWeight: "700",
+    fontSize: 13,
+  },
+  tabPillTextActive: {
+    color: "#fffaf2",
   },
   fieldGroup: {
     gap: 6,
@@ -361,6 +403,17 @@ export const appStyles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 20,
   },
+  embeddedScrollArea: {
+    maxHeight: 240,
+  },
+  embeddedScrollAreaTall: {
+    maxHeight: 320,
+  },
+  compactNote: {
+    color: colors.muted,
+    fontSize: 12,
+    lineHeight: 18,
+  },
   leadCopy: {
     color: colors.muted,
     fontSize: 15,
@@ -398,6 +451,13 @@ export const appStyles = StyleSheet.create({
   crowdRightColumn: {
     flex: 1.15,
     gap: 16,
+  },
+  linkGrid: {
+    gap: 10,
+  },
+  linkGridTablet: {
+    flexDirection: "row",
+    flexWrap: "wrap",
   },
   launchRoleGrid: {
     gap: 12,


### PR DESCRIPTION
## Summary
- compact the manager, member, and crowd mockups into denser dashboard-style layouts
- reduce vertical sprawl with focused panels, metric headers, and embedded list areas
- keep the crowd view tablet-friendly while making phone mockups feel more single-screen

## Testing
- `npx tsc --noEmit`

Closes #19
