### PR TITLE
Refine manager workspace for show-night control #21

### DIFF
--- a/src/screens/ManagerView.tsx
+++ b/src/screens/ManagerView.tsx
@@ -40,7 +40,7 @@ type ManagerActions = {
   clearRequest: (requestId: string) => void;
 };
 
-type ManagerPanel = "configure" | "catalog" | "show" | "queue";
+type ManagerPanel = "live" | "show" | "catalog" | "band" | "settings";
 
 export function ManagerView({
   activeShow,
@@ -60,8 +60,8 @@ export function ManagerView({
   actions: ManagerActions;
 }) {
   const { width } = useWindowDimensions();
-  const isTablet = width >= 980;
-  const [activePanel, setActivePanel] = useState<ManagerPanel>("show");
+  const isTablet = width >= 960;
+  const [activePanel, setActivePanel] = useState<ManagerPanel>("live");
   const [profile, setProfile] = useState({
     bandName: state.bandName,
     merchStore: state.links.merchStore,
@@ -103,6 +103,14 @@ export function ManagerView({
     }
   }, [selectedSongId, state.songs]);
 
+  const panelTabs: [ManagerPanel, string][] = [
+    ["live", "Live Desk"],
+    ["show", "Show Ops"],
+    ["catalog", "Catalog"],
+    ["band", "Band"],
+    ["settings", "Settings"],
+  ];
+
   return (
     <View style={styles.sectionStack}>
       <View style={styles.sectionHeader}>
@@ -111,41 +119,41 @@ export function ManagerView({
           <Text style={styles.sectionTitle}>Manager workspace</Text>
         </View>
         <Text style={styles.sectionCopy}>
-          The manager mockup is now organized like a control dashboard: overview first, then one
-          focused operating panel at a time.
+          This pass treats the manager role like a fast show-night control desk: live context first,
+          operational actions second, deeper setup last.
         </Text>
       </View>
 
       <SectionCard
         title={activeShow?.venue || state.bandName}
-        eyebrow={activeShow ? `Active show · ${helpers.formatDate(activeShow.date)}` : "Band overview"}
+        eyebrow={activeShow ? `Live show · ${helpers.formatDate(activeShow.date)}` : "Manager overview"}
       >
         <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
           <MetricCard
-            label="Queued requests"
+            label="Queue pressure"
             value={`${sortedRequests.length}`}
-            detail="Live demand to manage"
+            detail="Requests waiting right now"
           />
           <MetricCard
-            label="Tonight's tips"
+            label="Tracked tips"
             value={helpers.formatCurrency(totalTips)}
-            detail="Request boosts plus support"
+            detail="Requests plus support"
           />
           <MetricCard
-            label="Lineup ready"
-            value={`${activeShow?.lineup.length || 0}`}
-            detail={activeShow ? `${activeShow.city}` : "No active show"}
+            label="Set readiness"
+            value={`${activeShow?.setList.length || 0}`}
+            detail={activeShow ? "Songs attached to active show" : "No active show"}
+          />
+          <MetricCard
+            label="Split health"
+            value={`${splitTotal}%`}
+            detail={splitTotal === 100 ? "Balanced allocation" : "Needs adjustment"}
           />
         </View>
       </SectionCard>
 
       <View style={styles.tabRow}>
-        {([
-          ["show", "Show Ops"],
-          ["queue", "Queue"],
-          ["catalog", "Catalog"],
-          ["configure", "Config"],
-        ] as [ManagerPanel, string][]).map(([panel, label]) => {
+        {panelTabs.map(([panel, label]) => {
           const active = activePanel === panel;
           return (
             <Pressable
@@ -159,137 +167,43 @@ export function ManagerView({
         })}
       </View>
 
-      {activePanel === "configure" ? (
+      {activePanel === "live" ? (
         <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
-          <View style={styles.dashboardColumn}>
-            <SectionCard title="Band profile" eyebrow="Links and support handoff">
-              <TextInputField
-                label="Band name"
-                value={profile.bandName}
-                onChangeText={(text) => setProfile((current) => ({ ...current, bandName: text }))}
-              />
-              <TextInputField
-                label="Merch store"
-                value={profile.merchStore}
-                onChangeText={(text) => setProfile((current) => ({ ...current, merchStore: text }))}
-              />
-              <TextInputField
-                label="Show calendar"
-                value={profile.showCalendar}
-                onChangeText={(text) =>
-                  setProfile((current) => ({ ...current, showCalendar: text }))
-                }
-              />
-              <TextInputField
-                label="Venmo"
-                value={profile.venmo}
-                onChangeText={(text) => setProfile((current) => ({ ...current, venmo: text }))}
-              />
-              <TextInputField
-                label="Cash App"
-                value={profile.cashapp}
-                onChangeText={(text) => setProfile((current) => ({ ...current, cashapp: text }))}
-              />
-              <TextInputField
-                label="PayPal"
-                value={profile.paypal}
-                onChangeText={(text) => setProfile((current) => ({ ...current, paypal: text }))}
-              />
-              <PrimaryButton label="Save profile" onPress={() => actions.updateProfile(profile)} />
-            </SectionCard>
-          </View>
-
           <View style={styles.dashboardColumn}>
             <SectionCard
-              title="Access controls"
-              eyebrow="Local manager, member, and crowd device settings"
+              title="Live queue"
+              eyebrow={`${helpers.formatCurrency(totalTips)} tracked tonight`}
             >
-              <TextInputField
-                label="Manager passcode"
-                value={accessDraft.managerPin}
-                keyboardType="numeric"
-                onChangeText={(text) =>
-                  setAccessDraft((current) => ({ ...current, managerPin: text }))
-                }
-              />
-              <TextInputField
-                label="Band member passcode"
-                value={accessDraft.memberPin}
-                keyboardType="numeric"
-                onChangeText={(text) =>
-                  setAccessDraft((current) => ({ ...current, memberPin: text }))
-                }
-              />
-              <TextInputField
-                label="Crowd device label"
-                value={accessDraft.crowdLabel}
-                onChangeText={(text) =>
-                  setAccessDraft((current) => ({ ...current, crowdLabel: text }))
-                }
-              />
-              <PrimaryButton
-                label="Save access settings"
-                onPress={() =>
-                  actions.updateAccess({
-                    managerPin: accessDraft.managerPin.trim() || state.access.managerPin,
-                    memberPin: accessDraft.memberPin.trim() || state.access.memberPin,
-                    crowdLabel: accessDraft.crowdLabel.trim() || state.access.crowdLabel,
-                  })
-                }
-              />
-            </SectionCard>
-          </View>
-        </View>
-      ) : null}
-
-      {activePanel === "catalog" ? (
-        <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
-          <View style={styles.dashboardColumn}>
-            <SectionCard title="Song catalog" eyebrow={`${state.songs.length} songs in rotation`}>
-              <TextInputField
-                label="Song title"
-                value={songDraft.title}
-                onChangeText={(text) => setSongDraft((current) => ({ ...current, title: text }))}
-              />
-              <TextInputField
-                label="Original artist or note"
-                value={songDraft.artist}
-                onChangeText={(text) => setSongDraft((current) => ({ ...current, artist: text }))}
-              />
-              <TextInputField
-                label="Energy"
-                value={songDraft.energy}
-                onChangeText={(text) =>
-                  setSongDraft((current) => ({
-                    ...current,
-                    energy: helpers.normalizeEnergy(text),
-                  }))
-                }
-              />
-              <PrimaryButton
-                label="Add song"
-                onPress={() => {
-                  if (!songDraft.title.trim() || !songDraft.artist.trim()) {
-                    return;
-                  }
-                  actions.addSong({
-                    title: songDraft.title.trim(),
-                    artist: songDraft.artist.trim(),
-                    energy: songDraft.energy,
-                  });
-                  setSongDraft({ title: "", artist: "", energy: "Mid" });
-                }}
-              />
-              <ScrollView style={styles.embeddedScrollArea}>
+              <Text style={styles.compactNote}>
+                This is the fastest show-night moderation panel: watch demand, bump favorites, and
+                clear fulfilled requests without digging through setup forms.
+              </Text>
+              <ScrollView style={styles.embeddedScrollAreaTall}>
                 <View style={styles.stackGap}>
-                  {state.songs.map((song) => (
-                    <RowCard
-                      key={song.id}
-                      title={song.title}
-                      subtitle={`${song.artist} · ${song.energy} energy`}
-                      aside={<GhostButton label="Remove" onPress={() => actions.removeSong(song.id)} />}
-                    />
-                  ))}
+                  {sortedRequests.length ? (
+                    sortedRequests.map((request) => {
+                      const song = helpers.songById(request.songId);
+                      if (!song) {
+                        return null;
+                      }
+
+                      return (
+                        <RequestCard
+                          key={request.id}
+                          title={song.title}
+                          subtitle={`${song.artist} · ${request.requester}`}
+                          note={request.note || "No note"}
+                          value={`${helpers.formatCurrency(request.tip)} · ${request.upvotes} boosts`}
+                          primaryLabel="Boost +$5"
+                          primaryAction={() => actions.boostRequest(request.id)}
+                          secondaryLabel="Clear"
+                          secondaryAction={() => actions.clearRequest(request.id)}
+                        />
+                      );
+                    })
+                  ) : (
+                    <EmptyState label="No requests in the queue yet." />
+                  )}
                 </View>
               </ScrollView>
             </SectionCard>
@@ -297,69 +211,63 @@ export function ManagerView({
 
           <View style={styles.dashboardColumn}>
             <SectionCard
-              title="Band members"
-              eyebrow={`${state.members.length} active members`}
-              sideLabel={splitTotal === 100 ? "Splits total 100%" : `Splits total ${splitTotal}%`}
-              sideTone={splitTotal === 100 ? "good" : "warning"}
+              title="Tonight's show"
+              eyebrow={activeShow ? `${activeShow.city} · ${activeShow.notes || "No notes"}` : "No show selected"}
             >
-              <TextInputField
-                label="Member name"
-                value={memberDraft.name}
-                onChangeText={(text) => setMemberDraft((current) => ({ ...current, name: text }))}
-              />
-              <TextInputField
-                label="Role"
-                value={memberDraft.role}
-                onChangeText={(text) => setMemberDraft((current) => ({ ...current, role: text }))}
-              />
-              <TextInputField
-                label="Tip allocation %"
-                value={memberDraft.allocation}
-                keyboardType="numeric"
-                onChangeText={(text) =>
-                  setMemberDraft((current) => ({ ...current, allocation: text }))
-                }
-              />
-              <PrimaryButton
-                label="Add member"
-                onPress={() => {
-                  if (!memberDraft.name.trim() || !memberDraft.role.trim()) {
-                    return;
-                  }
-                  actions.addMember({
-                    name: memberDraft.name.trim(),
-                    role: memberDraft.role.trim(),
-                    allocation: Number(memberDraft.allocation) || 0,
-                  });
-                  setMemberDraft({ name: "", role: "", allocation: "25" });
-                }}
-              />
-              <ScrollView style={styles.embeddedScrollArea}>
-                <View style={styles.stackGap}>
-                  {state.members.map((member) => (
-                    <View key={member.id} style={styles.rowCard}>
-                      <View style={styles.rowMeta}>
-                        <Text style={styles.rowTitle}>{member.name}</Text>
-                        <Text style={styles.rowSubtitle}>{member.role}</Text>
-                      </View>
-                      <View style={styles.rowAside}>
-                        <TextInput
-                          style={[styles.input, styles.inlineAllocation]}
-                          value={String(member.allocation)}
-                          keyboardType="numeric"
-                          onChangeText={(text) =>
-                            actions.updateMemberAllocation(member.id, Number(text) || 0)
+              {activeShow ? (
+                <>
+                  <Text style={styles.subheading}>Lineup on deck</Text>
+                  <View style={styles.pillWrap}>
+                    {activeShow.lineup.length ? (
+                      activeShow.lineup.map((memberId) => {
+                        const member = state.members.find((entry) => entry.id === memberId);
+                        if (!member) {
+                          return null;
+                        }
+                        return (
+                          <View key={member.id} style={styles.personPill}>
+                            <Text style={styles.personPillTitle}>{member.name}</Text>
+                            <Text style={styles.personPillSubtitle}>{member.role}</Text>
+                          </View>
+                        );
+                      })
+                    ) : (
+                      <EmptyState label="No lineup assigned yet." />
+                    )}
+                  </View>
+
+                  <Text style={styles.subheading}>Set list</Text>
+                  <ScrollView style={styles.embeddedScrollArea}>
+                    <View style={styles.stackGap}>
+                      {activeShow.setList.length ? (
+                        activeShow.setList.map((songId, index) => {
+                          const song = helpers.songById(songId);
+                          if (!song) {
+                            return null;
                           }
-                        />
-                        <GhostButton
-                          label="Remove"
-                          onPress={() => actions.removeMember(member.id)}
-                        />
-                      </View>
+                          return (
+                            <RowCard
+                              key={`${songId}-${index}`}
+                              title={`${index + 1}. ${song.title}`}
+                              subtitle={`${song.artist} · ${song.energy} energy`}
+                              aside={
+                                <GhostButton
+                                  label="Remove"
+                                  onPress={() => actions.removeSongFromSetList(songId)}
+                                />
+                              }
+                            />
+                          );
+                        })
+                      ) : (
+                        <EmptyState label="No songs attached to the active show yet." />
+                      )}
                     </View>
-                  ))}
-                </View>
-              </ScrollView>
+                  </ScrollView>
+                </>
+              ) : (
+                <EmptyState label="Create or activate a show to manage lineup and set flow." />
+              )}
             </SectionCard>
           </View>
         </View>
@@ -368,10 +276,7 @@ export function ManagerView({
       {activePanel === "show" ? (
         <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
           <View style={styles.dashboardColumn}>
-            <SectionCard
-              title="Shows"
-              eyebrow={activeShow ? `Active show · ${activeShow.venue}` : "No active show"}
-            >
+            <SectionCard title="Shows" eyebrow={activeShow ? `Active · ${activeShow.venue}` : "Create next show"}>
               <TextInputField
                 label="Show date"
                 value={showDraft.date}
@@ -436,7 +341,7 @@ export function ManagerView({
             <SectionCard title="Active show ops" eyebrow={activeShow ? activeShow.city : "Assign a show"}>
               {activeShow ? (
                 <>
-                  <Text style={styles.subheading}>Lineup</Text>
+                  <Text style={styles.subheading}>Lineup toggles</Text>
                   <View style={styles.pillWrap}>
                     {state.members.map((member) => {
                       const active = activeShow.lineup.includes(member.id);
@@ -446,9 +351,7 @@ export function ManagerView({
                           onPress={() => actions.toggleLineupMember(member.id)}
                           style={[styles.togglePill, active && styles.togglePillActive]}
                         >
-                          <Text
-                            style={[styles.togglePillText, active && styles.togglePillTextActive]}
-                          >
+                          <Text style={[styles.togglePillText, active && styles.togglePillTextActive]}>
                             {member.name}
                           </Text>
                         </Pressable>
@@ -484,81 +387,218 @@ export function ManagerView({
                     label="Add selected song to set"
                     onPress={() => selectedSongId && actions.addSongToSetList(selectedSongId)}
                   />
-
-                  <ScrollView style={styles.embeddedScrollArea}>
-                    <View style={styles.stackGap}>
-                      {activeShow.setList.length ? (
-                        activeShow.setList.map((songId, index) => {
-                          const song = helpers.songById(songId);
-                          if (!song) {
-                            return null;
-                          }
-                          return (
-                            <RowCard
-                              key={`${songId}-${index}`}
-                              title={`${index + 1}. ${song.title}`}
-                              subtitle={`${song.artist} · ${song.energy} energy`}
-                              aside={
-                                <GhostButton
-                                  label="Remove"
-                                  onPress={() => actions.removeSongFromSetList(songId)}
-                                />
-                              }
-                            />
-                          );
-                        })
-                      ) : (
-                        <EmptyState label="No songs attached to the active show yet." />
-                      )}
-                    </View>
-                  </ScrollView>
                 </>
               ) : (
-                <EmptyState label="Create or activate a show to assign lineup and set list." />
+                <EmptyState label="Activate a show to manage lineup and set building." />
               )}
             </SectionCard>
           </View>
         </View>
       ) : null}
 
-      {activePanel === "queue" ? (
-        <SectionCard
-          title="Live queue"
-          eyebrow={`${helpers.formatCurrency(totalTips)} total tipped tonight`}
-        >
-          <Text style={styles.compactNote}>
-            Queue moderation now lives in its own focused panel so the mockup reads more like a live
-            console than a scrolling document.
-          </Text>
-          <ScrollView style={styles.embeddedScrollAreaTall}>
-            <View style={styles.stackGap}>
-              {sortedRequests.length ? (
-                sortedRequests.map((request) => {
-                  const song = helpers.songById(request.songId);
-                  if (!song) {
-                    return null;
+      {activePanel === "catalog" ? (
+        <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
+          <View style={styles.dashboardColumn}>
+            <SectionCard title="Add song" eyebrow="Keep the requestable catalog fresh">
+              <TextInputField
+                label="Song title"
+                value={songDraft.title}
+                onChangeText={(text) => setSongDraft((current) => ({ ...current, title: text }))}
+              />
+              <TextInputField
+                label="Original artist or note"
+                value={songDraft.artist}
+                onChangeText={(text) => setSongDraft((current) => ({ ...current, artist: text }))}
+              />
+              <TextInputField
+                label="Energy"
+                value={songDraft.energy}
+                onChangeText={(text) =>
+                  setSongDraft((current) => ({ ...current, energy: helpers.normalizeEnergy(text) }))
+                }
+              />
+              <PrimaryButton
+                label="Add song"
+                onPress={() => {
+                  if (!songDraft.title.trim() || !songDraft.artist.trim()) {
+                    return;
                   }
+                  actions.addSong({
+                    title: songDraft.title.trim(),
+                    artist: songDraft.artist.trim(),
+                    energy: songDraft.energy,
+                  });
+                  setSongDraft({ title: "", artist: "", energy: "Mid" });
+                }}
+              />
+            </SectionCard>
+          </View>
 
-                  return (
-                    <RequestCard
-                      key={request.id}
+          <View style={styles.dashboardColumn}>
+            <SectionCard title="Catalog" eyebrow={`${state.songs.length} songs in rotation`}>
+              <ScrollView style={styles.embeddedScrollAreaTall}>
+                <View style={styles.stackGap}>
+                  {state.songs.map((song) => (
+                    <RowCard
+                      key={song.id}
                       title={song.title}
-                      subtitle={`${song.artist} · ${request.requester}`}
-                      note={request.note || "No note"}
-                      value={`${helpers.formatCurrency(request.tip)} · ${request.upvotes} boosts`}
-                      primaryLabel="Boost +$5"
-                      primaryAction={() => actions.boostRequest(request.id)}
-                      secondaryLabel="Clear"
-                      secondaryAction={() => actions.clearRequest(request.id)}
+                      subtitle={`${song.artist} · ${song.energy} energy`}
+                      aside={<GhostButton label="Remove" onPress={() => actions.removeSong(song.id)} />}
                     />
-                  );
-                })
-              ) : (
-                <EmptyState label="No requests in the queue yet." />
-              )}
-            </View>
-          </ScrollView>
-        </SectionCard>
+                  ))}
+                </View>
+              </ScrollView>
+            </SectionCard>
+          </View>
+        </View>
+      ) : null}
+
+      {activePanel === "band" ? (
+        <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
+          <View style={styles.dashboardColumn}>
+            <SectionCard
+              title="Add member"
+              eyebrow={splitTotal === 100 ? "Splits balanced at 100%" : `Splits currently total ${splitTotal}%`}
+              sideLabel={splitTotal === 100 ? "Balanced" : "Needs review"}
+              sideTone={splitTotal === 100 ? "good" : "warning"}
+            >
+              <TextInputField
+                label="Member name"
+                value={memberDraft.name}
+                onChangeText={(text) => setMemberDraft((current) => ({ ...current, name: text }))}
+              />
+              <TextInputField
+                label="Role"
+                value={memberDraft.role}
+                onChangeText={(text) => setMemberDraft((current) => ({ ...current, role: text }))}
+              />
+              <TextInputField
+                label="Tip allocation %"
+                value={memberDraft.allocation}
+                keyboardType="numeric"
+                onChangeText={(text) =>
+                  setMemberDraft((current) => ({ ...current, allocation: text }))
+                }
+              />
+              <PrimaryButton
+                label="Add member"
+                onPress={() => {
+                  if (!memberDraft.name.trim() || !memberDraft.role.trim()) {
+                    return;
+                  }
+                  actions.addMember({
+                    name: memberDraft.name.trim(),
+                    role: memberDraft.role.trim(),
+                    allocation: Number(memberDraft.allocation) || 0,
+                  });
+                  setMemberDraft({ name: "", role: "", allocation: "25" });
+                }}
+              />
+            </SectionCard>
+          </View>
+
+          <View style={styles.dashboardColumn}>
+            <SectionCard title="Band members" eyebrow={`${state.members.length} members`}>
+              <ScrollView style={styles.embeddedScrollAreaTall}>
+                <View style={styles.stackGap}>
+                  {state.members.map((member) => (
+                    <View key={member.id} style={styles.rowCard}>
+                      <View style={styles.rowMeta}>
+                        <Text style={styles.rowTitle}>{member.name}</Text>
+                        <Text style={styles.rowSubtitle}>{member.role}</Text>
+                      </View>
+                      <View style={styles.rowAside}>
+                        <TextInput
+                          style={[styles.input, styles.inlineAllocation]}
+                          value={String(member.allocation)}
+                          keyboardType="numeric"
+                          onChangeText={(text) =>
+                            actions.updateMemberAllocation(member.id, Number(text) || 0)
+                          }
+                        />
+                        <GhostButton label="Remove" onPress={() => actions.removeMember(member.id)} />
+                      </View>
+                    </View>
+                  ))}
+                </View>
+              </ScrollView>
+            </SectionCard>
+          </View>
+        </View>
+      ) : null}
+
+      {activePanel === "settings" ? (
+        <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
+          <View style={styles.dashboardColumn}>
+            <SectionCard title="Band profile" eyebrow="Public links and handoff destinations">
+              <TextInputField
+                label="Band name"
+                value={profile.bandName}
+                onChangeText={(text) => setProfile((current) => ({ ...current, bandName: text }))}
+              />
+              <TextInputField
+                label="Merch store"
+                value={profile.merchStore}
+                onChangeText={(text) => setProfile((current) => ({ ...current, merchStore: text }))}
+              />
+              <TextInputField
+                label="Show calendar"
+                value={profile.showCalendar}
+                onChangeText={(text) =>
+                  setProfile((current) => ({ ...current, showCalendar: text }))
+                }
+              />
+              <TextInputField
+                label="Venmo"
+                value={profile.venmo}
+                onChangeText={(text) => setProfile((current) => ({ ...current, venmo: text }))}
+              />
+              <TextInputField
+                label="Cash App"
+                value={profile.cashapp}
+                onChangeText={(text) => setProfile((current) => ({ ...current, cashapp: text }))}
+              />
+              <TextInputField
+                label="PayPal"
+                value={profile.paypal}
+                onChangeText={(text) => setProfile((current) => ({ ...current, paypal: text }))}
+              />
+              <PrimaryButton label="Save profile" onPress={() => actions.updateProfile(profile)} />
+            </SectionCard>
+          </View>
+
+          <View style={styles.dashboardColumn}>
+            <SectionCard title="Access controls" eyebrow="Manager, member, and crowd device settings">
+              <TextInputField
+                label="Manager passcode"
+                value={accessDraft.managerPin}
+                keyboardType="numeric"
+                onChangeText={(text) => setAccessDraft((current) => ({ ...current, managerPin: text }))}
+              />
+              <TextInputField
+                label="Band member passcode"
+                value={accessDraft.memberPin}
+                keyboardType="numeric"
+                onChangeText={(text) => setAccessDraft((current) => ({ ...current, memberPin: text }))}
+              />
+              <TextInputField
+                label="Crowd device label"
+                value={accessDraft.crowdLabel}
+                onChangeText={(text) => setAccessDraft((current) => ({ ...current, crowdLabel: text }))}
+              />
+              <PrimaryButton
+                label="Save access settings"
+                onPress={() =>
+                  actions.updateAccess({
+                    managerPin: accessDraft.managerPin.trim() || state.access.managerPin,
+                    memberPin: accessDraft.memberPin.trim() || state.access.memberPin,
+                    crowdLabel: accessDraft.crowdLabel.trim() || state.access.crowdLabel,
+                  })
+                }
+              />
+            </SectionCard>
+          </View>
+        </View>
       ) : null}
     </View>
   );


### PR DESCRIPTION
## Summary
- rebuild the manager role as a focused show-night control desk
- prioritize live moderation and active show operations ahead of deeper setup work
- preserve all manager actions while reducing long-form dashboard sprawl

## Testing
- `npx tsc --noEmit`

Closes #21
