### PR TITLE
Hide app summary before provisioning #23

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -23,6 +23,7 @@ function App() {
   const activeRole = session.activeRole;
   const provisionedRole = session.deviceSession?.role ?? null;
   const shellState = appReady ? session.shellState : "hydrating";
+  const showAppSummary = shellState !== "setup";
 
   const workspaceTitle =
     provisionedRole === "crowd"
@@ -48,38 +49,40 @@ function App() {
       />
 
       <ScrollView style={styles.screen} contentContainerStyle={styles.screenContent}>
-        <View style={styles.hero}>
-          <View style={styles.heroMain}>
-            <Text style={styles.eyebrow}>Unified band operations</Text>
-            <Text style={styles.heroTitle}>StageHand</Text>
-            <Text style={styles.heroBody}>
-              Manager, band, and crowd tools now aim for a tighter dashboard feel instead of long
-              stacked mockups.
-            </Text>
-          </View>
+        {showAppSummary ? (
+          <View style={styles.hero}>
+            <View style={styles.heroMain}>
+              <Text style={styles.eyebrow}>Unified band operations</Text>
+              <Text style={styles.heroTitle}>StageHand</Text>
+              <Text style={styles.heroBody}>
+                Manager, band, and crowd tools now aim for a tighter dashboard feel instead of long
+                stacked mockups.
+              </Text>
+            </View>
 
-          <View style={[styles.heroStats, isTablet && styles.heroStatsTablet]}>
-            <MetricCard
-              label="Songs ready"
-              value={`${stagehand.state.songs.length}`}
-              detail="Live request catalog"
-            />
-            <MetricCard
-              label="Queued requests"
-              value={`${stagehand.sortedRequests.length}`}
-              detail="Room demand right now"
-            />
-            <MetricCard
-              label="Tonight's tips"
-              value={stagehand.helpers.formatCurrency(stagehand.totalTips)}
-              detail={
-                stagehand.activeShow
-                  ? `${stagehand.activeShow.venue} · ${stagehand.activeShow.city}`
-                  : "No active show"
-              }
-            />
+            <View style={[styles.heroStats, isTablet && styles.heroStatsTablet]}>
+              <MetricCard
+                label="Songs ready"
+                value={`${stagehand.state.songs.length}`}
+                detail="Live request catalog"
+              />
+              <MetricCard
+                label="Queued requests"
+                value={`${stagehand.sortedRequests.length}`}
+                detail="Room demand right now"
+              />
+              <MetricCard
+                label="Tonight's tips"
+                value={stagehand.helpers.formatCurrency(stagehand.totalTips)}
+                detail={
+                  stagehand.activeShow
+                    ? `${stagehand.activeShow.venue} · ${stagehand.activeShow.city}`
+                    : "No active show"
+                }
+              />
+            </View>
           </View>
-        </View>
+        ) : null}
 
         {shellState === "active" && activeRole !== "crowd" ? (
           <View style={styles.workspaceHeader}>


### PR DESCRIPTION
## Summary
- remove the app summary hero from the unprovisioned setup state
- keep the initial experience focused on device provisioning only
- preserve summary chrome for locked and active device sessions

## Testing
- `npx tsc --noEmit`

Closes #23
