### PR TITLE
Expand seed data for interface scale testing

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { SafeAreaView, ScrollView, Text, useWindowDimensions, View } from "react-native";
 
 import { StaffAccessModal } from "./src/components/StaffAccessModal";
-import { GhostButton, MetricCard } from "./src/components/ui";
+import { GhostButton } from "./src/components/ui";
 import { useStageHandState } from "./src/hooks/useStageHandState";
 import { useWorkspaceSession } from "./src/hooks/useWorkspaceSession";
 import { CrowdView } from "./src/screens/CrowdView";
@@ -23,7 +23,6 @@ function App() {
   const activeRole = session.activeRole;
   const provisionedRole = session.deviceSession?.role ?? null;
   const shellState = appReady ? session.shellState : "hydrating";
-  const showAppSummary = shellState !== "setup";
 
   const workspaceTitle =
     provisionedRole === "crowd"
@@ -49,41 +48,6 @@ function App() {
       />
 
       <ScrollView style={styles.screen} contentContainerStyle={styles.screenContent}>
-        {showAppSummary ? (
-          <View style={styles.hero}>
-            <View style={styles.heroMain}>
-              <Text style={styles.eyebrow}>Unified band operations</Text>
-              <Text style={styles.heroTitle}>StageHand</Text>
-              <Text style={styles.heroBody}>
-                Manager, band, and crowd tools now aim for a tighter dashboard feel instead of long
-                stacked mockups.
-              </Text>
-            </View>
-
-            <View style={[styles.heroStats, isTablet && styles.heroStatsTablet]}>
-              <MetricCard
-                label="Songs ready"
-                value={`${stagehand.state.songs.length}`}
-                detail="Live request catalog"
-              />
-              <MetricCard
-                label="Queued requests"
-                value={`${stagehand.sortedRequests.length}`}
-                detail="Room demand right now"
-              />
-              <MetricCard
-                label="Tonight's tips"
-                value={stagehand.helpers.formatCurrency(stagehand.totalTips)}
-                detail={
-                  stagehand.activeShow
-                    ? `${stagehand.activeShow.venue} · ${stagehand.activeShow.city}`
-                    : "No active show"
-                }
-              />
-            </View>
-          </View>
-        ) : null}
-
         {shellState === "active" && activeRole !== "crowd" ? (
           <View style={styles.workspaceHeader}>
             <View style={styles.workspaceHeaderCopy}>

--- a/App.tsx
+++ b/App.tsx
@@ -49,12 +49,22 @@ function App() {
 
       <ScrollView style={styles.screen} contentContainerStyle={styles.screenContent}>
         {shellState === "active" && activeRole !== "crowd" ? (
-          <View style={styles.workspaceHeader}>
-            <View style={styles.workspaceHeaderCopy}>
+          <View style={[styles.workspaceHeader, !isTablet && styles.workspaceHeaderStacked]}>
+            <View
+              style={[
+                styles.workspaceHeaderCopy,
+                !isTablet && styles.workspaceHeaderCopyStacked,
+              ]}
+            >
               <Text style={styles.eyebrow}>Current device session</Text>
               <Text style={styles.workspaceTitle}>{workspaceTitle}</Text>
             </View>
-            <View style={styles.workspaceActionGroup}>
+            <View
+              style={[
+                styles.workspaceActionGroup,
+                !isTablet && styles.workspaceActionGroupStacked,
+              ]}
+            >
               <GhostButton label="Lock device" onPress={session.lockWorkspace} />
               <GhostButton
                 label="Change device mode"

--- a/src/hooks/useStageHandState.ts
+++ b/src/hooks/useStageHandState.ts
@@ -277,6 +277,9 @@ export function useStageHandState() {
         ],
       }));
     },
+    resetDemoData: () => {
+      replaceState(() => buildSeedState());
+    },
   };
 
   return {

--- a/src/lib/stagehand.ts
+++ b/src/lib/stagehand.ts
@@ -1,8 +1,14 @@
 import { BandLinks, Member, Show, Song, SongEnergy, StageHandState } from "../types/stagehand";
 
-export const STORAGE_KEY = "stagehand-mobile-state-v1";
+export const STORAGE_KEY = "stagehand-mobile-state-v2";
 
 export const createId = () => Math.random().toString(36).slice(2, 10);
+
+export const dateFromToday = (offsetDays: number) => {
+  const date = new Date();
+  date.setDate(date.getDate() + offsetDays);
+  return date.toISOString().slice(0, 10);
+};
 
 export const nextFriday = () => {
   const date = new Date();
@@ -19,13 +25,48 @@ export const buildSeedState = (): StageHandState => {
     { id: createId(), title: "Tennessee Whiskey", artist: "Chris Stapleton", energy: "Low" },
     { id: createId(), title: "Valerie", artist: "Amy Winehouse", energy: "Mid" },
     { id: createId(), title: "Shut Up and Dance", artist: "Walk the Moon", energy: "High" },
+    { id: createId(), title: "Proud Mary", artist: "Creedence Clearwater Revival", energy: "High" },
+    { id: createId(), title: "Jolene", artist: "Dolly Parton", energy: "Mid" },
+    { id: createId(), title: "Brown Eyed Girl", artist: "Van Morrison", energy: "Mid" },
+    { id: createId(), title: "Rolling in the Deep", artist: "Adele", energy: "High" },
+    { id: createId(), title: "Fast Car", artist: "Tracy Chapman", energy: "Low" },
+    { id: createId(), title: "Take Me Home, Country Roads", artist: "John Denver", energy: "Mid" },
+    { id: createId(), title: "Don't Stop Believin'", artist: "Journey", energy: "High" },
+    { id: createId(), title: "Watermelon Sugar", artist: "Harry Styles", energy: "Mid" },
+    { id: createId(), title: "I Wanna Dance with Somebody", artist: "Whitney Houston", energy: "High" },
+    { id: createId(), title: "Landslide", artist: "Fleetwood Mac", energy: "Low" },
+    { id: createId(), title: "Wonderwall", artist: "Oasis", energy: "Mid" },
+    { id: createId(), title: "Levitating", artist: "Dua Lipa", energy: "High" },
+    { id: createId(), title: "Use Somebody", artist: "Kings of Leon", energy: "Mid" },
+    { id: createId(), title: "Before He Cheats", artist: "Carrie Underwood", energy: "High" },
+    { id: createId(), title: "No Diggity", artist: "Blackstreet", energy: "Mid" },
+    { id: createId(), title: "Ho Hey", artist: "The Lumineers", energy: "Mid" },
+    { id: createId(), title: "Faith", artist: "George Michael", energy: "High" },
+    { id: createId(), title: "Ain't No Sunshine", artist: "Bill Withers", energy: "Low" },
+    { id: createId(), title: "Sweet Caroline", artist: "Neil Diamond", energy: "Mid" },
+    { id: createId(), title: "Ex's & Oh's", artist: "Elle King", energy: "High" },
+    { id: createId(), title: "Kiss", artist: "Prince", energy: "High" },
+    { id: createId(), title: "Georgia on My Mind", artist: "Ray Charles", energy: "Low" },
+    { id: createId(), title: "Good as Hell", artist: "Lizzo", energy: "High" },
+    { id: createId(), title: "Riptide", artist: "Vance Joy", energy: "Mid" },
+    { id: createId(), title: "Stay", artist: "Rihanna", energy: "Low" },
+    { id: createId(), title: "Cake by the Ocean", artist: "DNCE", energy: "High" },
+    { id: createId(), title: "You Make My Dreams", artist: "Hall & Oates", energy: "High" },
+    { id: createId(), title: "The Story", artist: "Brandi Carlile", energy: "Mid" },
+    { id: createId(), title: "Crazy", artist: "Gnarls Barkley", energy: "Mid" },
+    { id: createId(), title: "September", artist: "Earth, Wind & Fire", energy: "High" },
+    { id: createId(), title: "Black Horse and the Cherry Tree", artist: "KT Tunstall", energy: "Mid" },
+    { id: createId(), title: "Love on the Brain", artist: "Rihanna", energy: "Low" },
+    { id: createId(), title: "Uptown Funk", artist: "Mark Ronson ft. Bruno Mars", energy: "High" },
   ];
 
   const members: Member[] = [
     { id: createId(), name: "Maya", role: "Lead Vocals", allocation: 35 },
-    { id: createId(), name: "Andre", role: "Guitar", allocation: 25 },
-    { id: createId(), name: "Riley", role: "Bass", allocation: 20 },
-    { id: createId(), name: "Theo", role: "Drums", allocation: 20 },
+    { id: createId(), name: "Andre", role: "Lead Guitar", allocation: 22 },
+    { id: createId(), name: "Riley", role: "Bass", allocation: 16 },
+    { id: createId(), name: "Theo", role: "Drums", allocation: 15 },
+    { id: createId(), name: "Jules", role: "Keys", allocation: 8 },
+    { id: createId(), name: "Nia", role: "Sax / Percussion", allocation: 4 },
   ];
 
   const headlineShow: Show = {
@@ -35,8 +76,66 @@ export const buildSeedState = (): StageHandState => {
     city: "Brooklyn, NY",
     notes: "Acoustic first set, full band second set",
     lineup: members.map((member) => member.id),
-    setList: songs.slice(0, 4).map((song) => song.id),
+    setList: songs.slice(0, 9).map((song) => song.id),
   };
+
+  const shows: Show[] = [
+    headlineShow,
+    {
+      id: createId(),
+      date: dateFromToday(-14),
+      venue: "Harbor Light",
+      city: "Jersey City, NJ",
+      notes: "Private event load-in at 5pm",
+      lineup: members.slice(0, 4).map((member) => member.id),
+      setList: songs.slice(10, 18).map((song) => song.id),
+    },
+    {
+      id: createId(),
+      date: dateFromToday(-7),
+      venue: "Juneberry Social",
+      city: "Philadelphia, PA",
+      notes: "Crowd skewed younger, keep second set upbeat",
+      lineup: members.map((member) => member.id),
+      setList: songs.slice(18, 27).map((song) => song.id),
+    },
+    {
+      id: createId(),
+      date: dateFromToday(6),
+      venue: "The Mariner",
+      city: "Asbury Park, NJ",
+      notes: "Outdoor patio set with short break between sets",
+      lineup: members.slice(0, 5).map((member) => member.id),
+      setList: songs.slice(4, 13).map((song) => song.id),
+    },
+    {
+      id: createId(),
+      date: dateFromToday(13),
+      venue: "Velvet Room",
+      city: "New York, NY",
+      notes: "Late-night room, lean funk and dance-heavy",
+      lineup: [members[0].id, members[1].id, members[2].id, members[3].id, members[5].id],
+      setList: songs.slice(24, 33).map((song) => song.id),
+    },
+    {
+      id: createId(),
+      date: dateFromToday(21),
+      venue: "Sparrow Hall",
+      city: "Hoboken, NJ",
+      notes: "Venue wants a tighter first set and strong singalongs late",
+      lineup: members.map((member) => member.id),
+      setList: songs.slice(6, 15).map((song) => song.id),
+    },
+    {
+      id: createId(),
+      date: dateFromToday(30),
+      venue: "Luna Lounge",
+      city: "Boston, MA",
+      notes: "Travel date, compact backline, no percussion riser",
+      lineup: members.slice(0, 5).map((member) => member.id),
+      setList: songs.slice(14, 23).map((song) => song.id),
+    },
+  ];
 
   return {
     bandName: "StageHand House Band",
@@ -54,7 +153,7 @@ export const buildSeedState = (): StageHandState => {
     },
     songs,
     members,
-    shows: [headlineShow],
+    shows,
     requests: [
       {
         id: createId(),
@@ -74,6 +173,78 @@ export const buildSeedState = (): StageHandState => {
         upvotes: 1,
         createdAt: Date.now() - 1000 * 60 * 12,
       },
+      {
+        id: createId(),
+        songId: songs[15].id,
+        requester: "Mina",
+        note: "For the rooftop crew",
+        tip: 18,
+        upvotes: 4,
+        createdAt: Date.now() - 1000 * 60 * 28,
+      },
+      {
+        id: createId(),
+        songId: songs[24].id,
+        requester: "Paul",
+        note: "We all know the chorus",
+        tip: 15,
+        upvotes: 5,
+        createdAt: Date.now() - 1000 * 60 * 26,
+      },
+      {
+        id: createId(),
+        songId: songs[33].id,
+        requester: "Anika",
+        note: "Dance floor is ready",
+        tip: 25,
+        upvotes: 6,
+        createdAt: Date.now() - 1000 * 60 * 22,
+      },
+      {
+        id: createId(),
+        songId: songs[10].id,
+        requester: "Drew",
+        note: "Table 6 singalong request",
+        tip: 9,
+        upvotes: 2,
+        createdAt: Date.now() - 1000 * 60 * 19,
+      },
+      {
+        id: createId(),
+        songId: songs[7].id,
+        requester: "Tori",
+        note: "",
+        tip: 10,
+        upvotes: 2,
+        createdAt: Date.now() - 1000 * 60 * 16,
+      },
+      {
+        id: createId(),
+        songId: songs[21].id,
+        requester: "Gabe",
+        note: "Bridal party request",
+        tip: 30,
+        upvotes: 7,
+        createdAt: Date.now() - 1000 * 60 * 11,
+      },
+      {
+        id: createId(),
+        songId: songs[28].id,
+        requester: "Helena",
+        note: "Would sound great acoustic",
+        tip: 8,
+        upvotes: 1,
+        createdAt: Date.now() - 1000 * 60 * 9,
+      },
+      {
+        id: createId(),
+        songId: songs[31].id,
+        requester: "Jon",
+        note: "Play this into the break",
+        tip: 14,
+        upvotes: 3,
+        createdAt: Date.now() - 1000 * 60 * 6,
+      },
     ],
     supportTips: [
       {
@@ -82,6 +253,34 @@ export const buildSeedState = (): StageHandState => {
         amount: 25,
         note: "You sound incredible tonight",
         createdAt: Date.now() - 1000 * 60 * 15,
+      },
+      {
+        id: createId(),
+        supporter: "Bree",
+        amount: 10,
+        note: "For the sax solos",
+        createdAt: Date.now() - 1000 * 60 * 24,
+      },
+      {
+        id: createId(),
+        supporter: "Marcus",
+        amount: 40,
+        note: "Thanks for learning our anniversary song",
+        createdAt: Date.now() - 1000 * 60 * 18,
+      },
+      {
+        id: createId(),
+        supporter: "Olive",
+        amount: 15,
+        note: "Come back next month",
+        createdAt: Date.now() - 1000 * 60 * 10,
+      },
+      {
+        id: createId(),
+        supporter: "Sofia",
+        amount: 20,
+        note: "The first set was perfect",
+        createdAt: Date.now() - 1000 * 60 * 4,
       },
     ],
     activeShowId: headlineShow.id,

--- a/src/screens/ManagerView.tsx
+++ b/src/screens/ManagerView.tsx
@@ -48,6 +48,7 @@ type ManagerActions = {
 };
 
 type ManagerMode = "active-show" | "planning";
+type ActivePanel = "queue" | "set" | "tonight";
 type PlanningPanel = "shows" | "catalog" | "band" | "settings";
 
 export function ManagerView({
@@ -70,6 +71,7 @@ export function ManagerView({
   const { width } = useWindowDimensions();
   const isTablet = width >= 900;
   const [mode, setMode] = React.useState<ManagerMode>("active-show");
+  const [activePanel, setActivePanel] = React.useState<ActivePanel>("queue");
   const [planningPanel, setPlanningPanel] = React.useState<PlanningPanel>("shows");
 
   const [songTitle, setSongTitle] = React.useState("");
@@ -131,18 +133,37 @@ export function ManagerView({
 
   const requestTipTotal = sortedRequests.reduce((sum, request) => sum + request.tip, 0);
   const supportTipTotal = totalTips - requestTipTotal;
-  const topRequests = sortedRequests.slice(0, 5);
-  const quickAddSongs = state.songs.slice(0, 8);
+  const topRequests = sortedRequests.slice(0, 10);
+  const quickAddSongs = state.songs.slice(0, 12);
+
+  const secondaryTabs =
+    mode === "active-show"
+      ? ([
+          ["queue", "Queue"],
+          ["set", "Set"],
+          ["tonight", "Tonight"],
+        ] as [ActivePanel, string][])
+      : ([
+          ["shows", "Shows"],
+          ["catalog", "Catalog"],
+          ["band", "Band"],
+          ["settings", "Settings"],
+        ] as [PlanningPanel, string][]);
+
+  const secondarySelection = mode === "active-show" ? activePanel : planningPanel;
+  const toolbarMeta =
+    mode === "active-show"
+      ? activeShow
+        ? `${activeShow.venue} · ${helpers.formatDate(activeShow.date)}`
+        : "Select or create a show in Planning to run the room."
+      : activeShow
+        ? `Planning for ${activeShow.venue} · ${activeShow.city}`
+        : "Planning workspace ready for shows, catalog, band, and settings.";
 
   return (
     <View style={styles.sectionStack}>
-      <SectionCard
-        title={mode === "active-show" ? "Active Show" : "Planning / Pre-Show"}
-        eyebrow={activeShow ? `${helpers.formatDate(activeShow.date)} · ${activeShow.venue}` : "No active show"}
-        sideLabel={mode === "active-show" ? "Live desk" : "Prep mode"}
-        sideTone={mode === "active-show" ? "good" : "warning"}
-      >
-        <View style={styles.tabRow}>
+      <View style={styles.toolbarShell}>
+        <View style={styles.toolbarRow}>
           {([
             ["active-show", "Active Show"],
             ["planning", "Planning / Pre-Show"],
@@ -152,499 +173,433 @@ export function ManagerView({
               <Pressable
                 key={value}
                 onPress={() => setMode(value)}
-                style={[styles.tabPill, selected && styles.tabPillActive]}
+                style={[styles.toolbarPill, selected && styles.toolbarPillActive]}
               >
-                <Text style={[styles.tabPillText, selected && styles.tabPillTextActive]}>
+                <Text style={[styles.toolbarPillText, selected && styles.toolbarPillTextActive]}>
                   {label}
                 </Text>
               </Pressable>
             );
           })}
         </View>
-        <Text style={styles.compactNote}>
-          {mode === "active-show"
-            ? "Run the room from here: queue, set flow, and tips."
-            : "Prep here without the noise of live-show controls."}
-        </Text>
-      </SectionCard>
 
-      {mode === "active-show" ? (
-        <View style={styles.sectionStack}>
-          <SectionCard
-            title={activeShow?.venue || "No active show selected"}
-            eyebrow={activeShow ? `${helpers.formatDate(activeShow.date)} · ${activeShow.city}` : "Show activation needed"}
-          >
-            <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
-              <MetricCard
-                label="Requests"
-                value={`${sortedRequests.length}`}
-                detail={topRequests.length ? "Top requests are ready to work" : "Queue is quiet"}
-              />
-              <MetricCard
-                label="Set"
-                value={`${activeSetSongs.length} songs`}
-                detail={activeSetSongs[0] ? `Next up: ${activeSetSongs[0].song.title}` : "No set staged yet"}
-              />
-              <MetricCard
-                label="Tips"
-                value={helpers.formatCurrency(totalTips)}
-                detail={`${helpers.formatCurrency(requestTipTotal)} requests · ${helpers.formatCurrency(supportTipTotal)} support`}
-              />
-            </View>
-          </SectionCard>
-
-          <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
-            <View style={styles.dashboardColumn}>
-              <SectionCard
-                title="Request queue"
-                eyebrow={topRequests.length ? "Showing the highest-priority songs first" : "No requests waiting"}
+        <View style={styles.toolbarRow}>
+          {secondaryTabs.map(([value, label]) => {
+            const selected = secondarySelection === value;
+            return (
+              <Pressable
+                key={value}
+                onPress={() =>
+                  mode === "active-show"
+                    ? setActivePanel(value as ActivePanel)
+                    : setPlanningPanel(value as PlanningPanel)
+                }
+                style={[styles.toolbarPill, selected && styles.toolbarPillActive]}
               >
-                <ScrollView style={styles.embeddedScrollAreaTall}>
-                  <View style={styles.stackGap}>
-                    {topRequests.length ? (
-                      topRequests.map((request) => {
-                        const song = helpers.songById(request.songId);
-                        if (!song) {
-                          return null;
-                        }
-
-                        return (
-                          <View key={request.id} style={styles.rowCard}>
-                            <View style={styles.rowMeta}>
-                              <Text style={styles.rowTitle}>{song.title}</Text>
-                              <Text style={styles.rowSubtitle}>
-                                {request.requester} · {helpers.formatCurrency(request.tip)} · {request.upvotes} boosts
-                              </Text>
-                              {request.note ? <Text style={styles.compactNote}>{request.note}</Text> : null}
-                            </View>
-                            <View style={styles.actionRow}>
-                              <GhostButton label="Boost" onPress={() => actions.boostRequest(request.id)} />
-                              <GhostButton label="Clear" onPress={() => actions.clearRequest(request.id)} />
-                            </View>
-                          </View>
-                        );
-                      })
-                    ) : (
-                      <EmptyState label="The room is clear right now. New requests will land here." />
-                    )}
-                  </View>
-                </ScrollView>
-                {sortedRequests.length > topRequests.length ? (
-                  <Text style={styles.compactNote}>
-                    {sortedRequests.length - topRequests.length} more requests remain below the fold.
-                  </Text>
-                ) : null}
-              </SectionCard>
-            </View>
-
-            <View style={styles.dashboardColumn}>
-              <SectionCard
-                title="Running set"
-                eyebrow={activeShow ? `${activeSetSongs.length} songs staged` : "Activate a show to manage the set"}
-              >
-                <ScrollView style={styles.embeddedScrollArea}>
-                  <View style={styles.stackGap}>
-                    {activeSetSongs.length ? (
-                      activeSetSongs.slice(0, 6).map(({ song, index }) => (
-                        <RowCard
-                          key={`${song.id}-${index}`}
-                          title={`${index + 1}. ${song.title}`}
-                          subtitle={`${song.artist} · ${song.energy} energy`}
-                          aside={<GhostButton label="Remove" onPress={() => actions.removeSongFromSetList(song.id)} />}
-                        />
-                      ))
-                    ) : (
-                      <EmptyState label="No songs are staged for the current set yet." />
-                    )}
-                  </View>
-                </ScrollView>
-                <Text style={styles.fieldLabel}>Quick add</Text>
-                <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-                  <View style={styles.pillWrap}>
-                    {quickAddSongs.map((song) => (
-                      <Pressable
-                        key={song.id}
-                        onPress={() => actions.addSongToSetList(song.id)}
-                        style={styles.selectPill}
-                      >
-                        <Text style={styles.selectPillText}>{song.title}</Text>
-                      </Pressable>
-                    ))}
-                  </View>
-                </ScrollView>
-              </SectionCard>
-
-              <SectionCard
-                title="Tonight"
-                eyebrow={lineupMembers.length ? `${lineupMembers.length} people assigned` : "No lineup assigned yet"}
-              >
-                <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
-                  <MetricCard
-                    label="Request tips"
-                    value={helpers.formatCurrency(requestTipTotal)}
-                    detail={`${sortedRequests.length} request entries`}
-                  />
-                  <MetricCard
-                    label="Direct support"
-                    value={helpers.formatCurrency(supportTipTotal)}
-                    detail="Walk-up and support tips"
-                  />
-                </View>
-                <View style={styles.pillWrap}>
-                  {lineupMembers.length ? (
-                    lineupMembers.map((member) => (
-                      <View key={member.id} style={styles.personPill}>
-                        <Text style={styles.personPillTitle}>{member.name}</Text>
-                        <Text style={styles.personPillSubtitle}>{member.role}</Text>
-                      </View>
-                    ))
-                  ) : (
-                    <EmptyState label="Assign a lineup in Planning / Pre-Show first." />
-                  )}
-                </View>
-              </SectionCard>
-            </View>
-          </View>
+                <Text style={[styles.toolbarPillText, selected && styles.toolbarPillTextActive]}>
+                  {label}
+                </Text>
+              </Pressable>
+            );
+          })}
         </View>
-      ) : (
-        <View style={styles.sectionStack}>
-          <SectionCard
-            title={activeShow?.venue || "Planning workspace"}
-            eyebrow={activeShow ? `${helpers.formatDate(activeShow.date)} · ${activeShow.city}` : "Choose or create a show"}
-          >
-            <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-              <View style={styles.pillWrap}>
-                {state.shows.map((show) => {
-                  const selected = show.id === activeShow?.id;
+
+        <Text style={styles.toolbarMeta}>{toolbarMeta}</Text>
+      </View>
+
+      {mode === "active-show" && activePanel === "queue" ? (
+        <SectionCard
+          title="Request queue"
+          eyebrow={topRequests.length ? `${sortedRequests.length} requests waiting` : "No requests waiting"}
+        >
+          <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
+            <MetricCard
+              label="Live requests"
+              value={`${sortedRequests.length}`}
+              detail="Highest-priority requests first"
+            />
+            <MetricCard
+              label="Request tips"
+              value={helpers.formatCurrency(requestTipTotal)}
+              detail="Crowd-driven demand right now"
+            />
+          </View>
+          <ScrollView style={styles.embeddedScrollAreaTall}>
+            <View style={styles.stackGap}>
+              {topRequests.length ? (
+                topRequests.map((request) => {
+                  const song = helpers.songById(request.songId);
+                  if (!song) {
+                    return null;
+                  }
                   return (
-                    <Pressable
-                      key={show.id}
-                      onPress={() => actions.setActiveShow(show.id)}
-                      style={[styles.selectPill, selected && styles.selectPillActive]}
-                    >
-                      <Text style={[styles.selectPillText, selected && styles.selectPillTextActive]}>
-                        {show.venue}
-                      </Text>
-                    </Pressable>
+                    <View key={request.id} style={styles.rowCard}>
+                      <View style={styles.rowMeta}>
+                        <Text style={styles.rowTitle}>{song.title}</Text>
+                        <Text style={styles.rowSubtitle}>
+                          {request.requester} · {helpers.formatCurrency(request.tip)} · {request.upvotes} boosts
+                        </Text>
+                        {request.note ? <Text style={styles.compactNote}>{request.note}</Text> : null}
+                      </View>
+                      <View style={styles.actionRow}>
+                        <GhostButton label="Boost" onPress={() => actions.boostRequest(request.id)} />
+                        <GhostButton label="Clear" onPress={() => actions.clearRequest(request.id)} />
+                      </View>
+                    </View>
                   );
-                })}
-              </View>
-            </ScrollView>
-            <View style={styles.tabRow}>
-              {([
-                ["shows", "Shows"],
-                ["catalog", "Catalog"],
-                ["band", "Band"],
-                ["settings", "Settings"],
-              ] as [PlanningPanel, string][]).map(([value, label]) => {
-                const selected = planningPanel === value;
-                return (
-                  <Pressable
-                    key={value}
-                    onPress={() => setPlanningPanel(value)}
-                    style={[styles.tabPill, selected && styles.tabPillActive]}
-                  >
-                    <Text style={[styles.tabPillText, selected && styles.tabPillTextActive]}>
-                      {label}
+                })
+              ) : (
+                <EmptyState label="The room is clear right now. New requests will land here." />
+              )}
+            </View>
+          </ScrollView>
+        </SectionCard>
+      ) : null}
+
+      {mode === "active-show" && activePanel === "set" ? (
+        <SectionCard
+          title="Running set"
+          eyebrow={activeShow ? `${activeSetSongs.length} songs staged for ${activeShow.venue}` : "No active show selected"}
+        >
+          <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
+            <MetricCard
+              label="Set size"
+              value={`${activeSetSongs.length}`}
+              detail={activeSetSongs[0] ? `Next up: ${activeSetSongs[0].song.title}` : "No next song staged"}
+            />
+            <MetricCard
+              label="Quick add"
+              value={`${quickAddSongs.length}`}
+              detail="Top catalog shortcuts available below"
+            />
+          </View>
+          <ScrollView style={styles.embeddedScrollAreaTall}>
+            <View style={styles.stackGap}>
+              {activeSetSongs.length ? (
+                activeSetSongs.map(({ song, index }) => (
+                  <RowCard
+                    key={`${song.id}-${index}`}
+                    title={`${index + 1}. ${song.title}`}
+                    subtitle={`${song.artist} · ${song.energy} energy`}
+                    aside={<GhostButton label="Remove" onPress={() => actions.removeSongFromSetList(song.id)} />}
+                  />
+                ))
+              ) : (
+                <EmptyState label="No songs are staged for the current set yet." />
+              )}
+            </View>
+          </ScrollView>
+          <Text style={styles.fieldLabel}>Quick add from catalog</Text>
+          <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+            <View style={styles.pillWrap}>
+              {quickAddSongs.map((song) => (
+                <Pressable
+                  key={song.id}
+                  onPress={() => actions.addSongToSetList(song.id)}
+                  style={styles.selectPill}
+                >
+                  <Text style={styles.selectPillText}>{song.title}</Text>
+                </Pressable>
+              ))}
+            </View>
+          </ScrollView>
+        </SectionCard>
+      ) : null}
+
+      {mode === "active-show" && activePanel === "tonight" ? (
+        <SectionCard
+          title="Tonight"
+          eyebrow={activeShow ? `${activeShow.venue} · ${activeShow.city}` : "No active show selected"}
+        >
+          <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
+            <MetricCard
+              label="Tips"
+              value={helpers.formatCurrency(totalTips)}
+              detail={`${helpers.formatCurrency(requestTipTotal)} requests · ${helpers.formatCurrency(supportTipTotal)} support`}
+            />
+            <MetricCard
+              label="Lineup"
+              value={`${lineupMembers.length}`}
+              detail="Players assigned to this show"
+            />
+            <MetricCard
+              label="Support tips"
+              value={helpers.formatCurrency(supportTipTotal)}
+              detail="Direct support during the show"
+            />
+          </View>
+          <Text style={styles.fieldLabel}>Lineup</Text>
+          <View style={styles.pillWrap}>
+            {lineupMembers.length ? (
+              lineupMembers.map((member) => (
+                <View key={member.id} style={styles.personPill}>
+                  <Text style={styles.personPillTitle}>{member.name}</Text>
+                  <Text style={styles.personPillSubtitle}>
+                    {member.role} · {member.allocation}% split
+                  </Text>
+                </View>
+              ))
+            ) : (
+              <EmptyState label="Assign a lineup in Planning first." />
+            )}
+          </View>
+          <Text style={styles.fieldLabel}>Payout snapshot</Text>
+          <ScrollView style={styles.embeddedScrollArea}>
+            <View style={styles.stackGap}>
+              {state.members.map((member) => (
+                <RowCard
+                  key={member.id}
+                  title={member.name}
+                  subtitle={`${member.role} · ${member.allocation}% share`}
+                  aside={
+                    <Text style={styles.moneyText}>
+                      {helpers.formatCurrency(totalTips * (member.allocation / 100))}
                     </Text>
-                  </Pressable>
-                );
-              })}
+                  }
+                />
+              ))}
             </View>
-          </SectionCard>
+          </ScrollView>
+        </SectionCard>
+      ) : null}
 
-          {planningPanel === "shows" ? (
-            <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
-              <View style={styles.dashboardColumn}>
-                <SectionCard
-                  title="Show roster"
-                  eyebrow={`${state.shows.length} shows in rotation`}
-                >
-                  <ScrollView style={styles.embeddedScrollAreaTall}>
-                    <View style={styles.stackGap}>
-                      {state.shows.map((show) => (
-                        <RowCard
-                          key={show.id}
-                          title={`${show.venue} · ${show.city}`}
-                          subtitle={`${helpers.formatDate(show.date)} · ${show.notes || "No notes yet"}`}
-                          aside={
-                            <>
-                              <GhostButton label="Open" onPress={() => actions.setActiveShow(show.id)} />
-                              {state.shows.length > 1 ? (
-                                <GhostButton label="Remove" onPress={() => actions.removeShow(show.id)} />
-                              ) : null}
-                            </>
-                          }
-                        />
-                      ))}
-                    </View>
-                  </ScrollView>
-                  <TextInputField label="Show date" value={showDate} onChangeText={setShowDate} />
-                  <TextInputField label="Venue" value={showVenue} onChangeText={setShowVenue} />
-                  <TextInputField label="City" value={showCity} onChangeText={setShowCity} />
-                  <TextInputField label="Notes" value={showNotes} onChangeText={setShowNotes} />
-                  <PrimaryButton
-                    label="Add show"
-                    onPress={() => {
-                      if (!showDate.trim() || !showVenue.trim() || !showCity.trim()) {
-                        return;
-                      }
-                      actions.addShow({
-                        date: showDate.trim(),
-                        venue: showVenue.trim(),
-                        city: showCity.trim(),
-                        notes: showNotes.trim(),
-                      });
-                      setShowVenue("");
-                      setShowCity("");
-                      setShowNotes("");
-                    }}
-                  />
-                </SectionCard>
-              </View>
-
-              <View style={styles.dashboardColumn}>
-                <SectionCard
-                  title="Show setup"
-                  eyebrow={activeShow ? `Editing ${activeShow.venue}` : "Select a show first"}
-                >
-                  <Text style={styles.fieldLabel}>Lineup</Text>
-                  <View style={styles.pillWrap}>
-                    {state.members.map((member) => {
-                      const selected = activeShow?.lineup.includes(member.id) ?? false;
-                      return (
-                        <Pressable
-                          key={member.id}
-                          onPress={() => actions.toggleLineupMember(member.id)}
-                          style={[styles.togglePill, selected && styles.togglePillActive]}
-                        >
-                          <Text style={[styles.togglePillText, selected && styles.togglePillTextActive]}>
-                            {member.name}
-                          </Text>
-                        </Pressable>
-                      );
-                    })}
-                  </View>
-                  <Text style={styles.fieldLabel}>Prepared setlist</Text>
-                  <ScrollView style={styles.embeddedScrollArea}>
-                    <View style={styles.stackGap}>
-                      {activeSetSongs.length ? (
-                        activeSetSongs.map(({ song, index }) => (
-                          <RowCard
-                            key={`${song.id}-${index}-planning`}
-                            title={`${index + 1}. ${song.title}`}
-                            subtitle={`${song.artist} · ${song.energy} energy`}
-                            aside={<GhostButton label="Remove" onPress={() => actions.removeSongFromSetList(song.id)} />}
-                          />
-                        ))
-                      ) : (
-                        <EmptyState label="No songs staged for this show yet." />
-                      )}
-                    </View>
-                  </ScrollView>
-                  <Text style={styles.fieldLabel}>Add songs to this show</Text>
-                  <ScrollView horizontal showsHorizontalScrollIndicator={false}>
-                    <View style={styles.pillWrap}>
-                      {state.songs.map((song) => (
-                        <Pressable
-                          key={`${song.id}-planning`}
-                          onPress={() => actions.addSongToSetList(song.id)}
-                          style={styles.selectPill}
-                        >
-                          <Text style={styles.selectPillText}>{song.title}</Text>
-                        </Pressable>
-                      ))}
-                    </View>
-                  </ScrollView>
-                </SectionCard>
-              </View>
+      {mode === "planning" && planningPanel === "shows" ? (
+        <SectionCard
+          title="Shows"
+          eyebrow={`${state.shows.length} shows in rotation`}
+        >
+          <ScrollView style={styles.embeddedScrollAreaTall}>
+            <View style={styles.stackGap}>
+              {state.shows.map((show) => (
+                <RowCard
+                  key={show.id}
+                  title={`${show.venue} · ${show.city}`}
+                  subtitle={`${helpers.formatDate(show.date)} · ${show.notes || "No notes yet"}`}
+                  aside={
+                    <>
+                      <GhostButton label="Open" onPress={() => actions.setActiveShow(show.id)} />
+                      {state.shows.length > 1 ? (
+                        <GhostButton label="Remove" onPress={() => actions.removeShow(show.id)} />
+                      ) : null}
+                    </>
+                  }
+                />
+              ))}
             </View>
-          ) : null}
-
-          {planningPanel === "catalog" ? (
-            <SectionCard
-              title="Song catalog"
-              eyebrow={`${state.songs.length} songs available for requests and sets`}
-            >
-              <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
-                <View style={styles.dashboardColumn}>
-                  <TextInputField label="Song title" value={songTitle} onChangeText={setSongTitle} />
-                  <TextInputField label="Artist" value={songArtist} onChangeText={setSongArtist} />
-                  <Text style={styles.fieldLabel}>Energy</Text>
-                  <View style={styles.pillWrap}>
-                    {(["Low", "Mid", "High"] as Song["energy"][]).map((energy) => {
-                      const selected = songEnergy === energy;
-                      return (
-                        <Pressable
-                          key={energy}
-                          onPress={() => setSongEnergy(energy)}
-                          style={[styles.selectPill, selected && styles.selectPillActive]}
-                        >
-                          <Text style={[styles.selectPillText, selected && styles.selectPillTextActive]}>
-                            {energy}
-                          </Text>
-                        </Pressable>
-                      );
-                    })}
-                  </View>
-                  <PrimaryButton
-                    label="Add song"
-                    onPress={() => {
-                      if (!songTitle.trim() || !songArtist.trim()) {
-                        return;
-                      }
-                      actions.addSong({
-                        title: songTitle.trim(),
-                        artist: songArtist.trim(),
-                        energy: helpers.normalizeEnergy(songEnergy),
-                      });
-                      setSongTitle("");
-                      setSongArtist("");
-                      setSongEnergy("Mid");
-                    }}
+          </ScrollView>
+          <TextInputField label="Show date" value={showDate} onChangeText={setShowDate} />
+          <TextInputField label="Venue" value={showVenue} onChangeText={setShowVenue} />
+          <TextInputField label="City" value={showCity} onChangeText={setShowCity} />
+          <TextInputField label="Notes" value={showNotes} onChangeText={setShowNotes} />
+          <PrimaryButton
+            label="Add show"
+            onPress={() => {
+              if (!showDate.trim() || !showVenue.trim() || !showCity.trim()) {
+                return;
+              }
+              actions.addShow({
+                date: showDate.trim(),
+                venue: showVenue.trim(),
+                city: showCity.trim(),
+                notes: showNotes.trim(),
+              });
+              setShowVenue("");
+              setShowCity("");
+              setShowNotes("");
+            }}
+          />
+          <Text style={styles.fieldLabel}>Selected show lineup</Text>
+          <View style={styles.pillWrap}>
+            {state.members.map((member) => {
+              const selected = activeShow?.lineup.includes(member.id) ?? false;
+              return (
+                <Pressable
+                  key={member.id}
+                  onPress={() => actions.toggleLineupMember(member.id)}
+                  style={[styles.togglePill, selected && styles.togglePillActive]}
+                >
+                  <Text style={[styles.togglePillText, selected && styles.togglePillTextActive]}>
+                    {member.name}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          <Text style={styles.fieldLabel}>Prepared setlist</Text>
+          <ScrollView style={styles.embeddedScrollArea}>
+            <View style={styles.stackGap}>
+              {activeSetSongs.length ? (
+                activeSetSongs.map(({ song, index }) => (
+                  <RowCard
+                    key={`${song.id}-${index}-planning`}
+                    title={`${index + 1}. ${song.title}`}
+                    subtitle={`${song.artist} · ${song.energy} energy`}
+                    aside={<GhostButton label="Remove" onPress={() => actions.removeSongFromSetList(song.id)} />}
                   />
-                </View>
+                ))
+              ) : (
+                <EmptyState label="No songs staged for the selected show yet." />
+              )}
+            </View>
+          </ScrollView>
+        </SectionCard>
+      ) : null}
 
-                <View style={styles.dashboardColumn}>
-                  <ScrollView style={styles.embeddedScrollAreaTall}>
-                    <View style={styles.stackGap}>
-                      {state.songs.map((song) => (
-                        <RowCard
-                          key={song.id}
-                          title={song.title}
-                          subtitle={`${song.artist} · ${song.energy} energy`}
-                          aside={<GhostButton label="Remove" onPress={() => actions.removeSong(song.id)} />}
-                        />
-                      ))}
-                    </View>
-                  </ScrollView>
-                </View>
-              </View>
-            </SectionCard>
-          ) : null}
+      {mode === "planning" && planningPanel === "catalog" ? (
+        <SectionCard
+          title="Song catalog"
+          eyebrow={`${state.songs.length} songs available for requests and sets`}
+        >
+          <TextInputField label="Song title" value={songTitle} onChangeText={setSongTitle} />
+          <TextInputField label="Artist" value={songArtist} onChangeText={setSongArtist} />
+          <Text style={styles.fieldLabel}>Energy</Text>
+          <View style={styles.pillWrap}>
+            {(["Low", "Mid", "High"] as Song["energy"][]).map((energy) => {
+              const selected = songEnergy === energy;
+              return (
+                <Pressable
+                  key={energy}
+                  onPress={() => setSongEnergy(energy)}
+                  style={[styles.selectPill, selected && styles.selectPillActive]}
+                >
+                  <Text style={[styles.selectPillText, selected && styles.selectPillTextActive]}>
+                    {energy}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          <PrimaryButton
+            label="Add song"
+            onPress={() => {
+              if (!songTitle.trim() || !songArtist.trim()) {
+                return;
+              }
+              actions.addSong({
+                title: songTitle.trim(),
+                artist: songArtist.trim(),
+                energy: helpers.normalizeEnergy(songEnergy),
+              });
+              setSongTitle("");
+              setSongArtist("");
+              setSongEnergy("Mid");
+            }}
+          />
+          <ScrollView style={styles.embeddedScrollAreaTall}>
+            <View style={styles.stackGap}>
+              {state.songs.map((song) => (
+                <RowCard
+                  key={song.id}
+                  title={song.title}
+                  subtitle={`${song.artist} · ${song.energy} energy`}
+                  aside={<GhostButton label="Remove" onPress={() => actions.removeSong(song.id)} />}
+                />
+              ))}
+            </View>
+          </ScrollView>
+        </SectionCard>
+      ) : null}
 
-          {planningPanel === "band" ? (
-            <SectionCard
-              title="Band + payouts"
-              eyebrow={`${splitTotal}% total split configured`}
-              sideLabel={splitTotal === 100 ? "Balanced" : "Needs review"}
-              sideTone={splitTotal === 100 ? "good" : "warning"}
-            >
-              <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
-                <View style={styles.dashboardColumn}>
-                  <TextInputField label="Member name" value={memberName} onChangeText={setMemberName} />
-                  <TextInputField label="Role" value={memberRole} onChangeText={setMemberRole} />
+      {mode === "planning" && planningPanel === "band" ? (
+        <SectionCard
+          title="Band + payouts"
+          eyebrow={`${splitTotal}% total split configured`}
+          sideLabel={splitTotal === 100 ? "Balanced" : "Needs review"}
+          sideTone={splitTotal === 100 ? "good" : "warning"}
+        >
+          <TextInputField label="Member name" value={memberName} onChangeText={setMemberName} />
+          <TextInputField label="Role" value={memberRole} onChangeText={setMemberRole} />
+          <TextInputField
+            label="Split %"
+            value={memberAllocation}
+            keyboardType="numeric"
+            onChangeText={setMemberAllocation}
+          />
+          <PrimaryButton
+            label="Add member"
+            onPress={() => {
+              if (!memberName.trim() || !memberRole.trim()) {
+                return;
+              }
+              actions.addMember({
+                name: memberName.trim(),
+                role: memberRole.trim(),
+                allocation: Number(memberAllocation) || 0,
+              });
+              setMemberName("");
+              setMemberRole("");
+              setMemberAllocation("20");
+            }}
+          />
+          <ScrollView style={styles.embeddedScrollAreaTall}>
+            <View style={styles.stackGap}>
+              {state.members.map((member) => (
+                <View key={member.id} style={styles.rowCard}>
+                  <View style={styles.rowMeta}>
+                    <Text style={styles.rowTitle}>{member.name}</Text>
+                    <Text style={styles.rowSubtitle}>{member.role}</Text>
+                  </View>
                   <TextInputField
                     label="Split %"
-                    value={memberAllocation}
+                    value={`${member.allocation}`}
                     keyboardType="numeric"
-                    onChangeText={setMemberAllocation}
-                  />
-                  <PrimaryButton
-                    label="Add member"
-                    onPress={() => {
-                      if (!memberName.trim() || !memberRole.trim()) {
-                        return;
-                      }
-                      actions.addMember({
-                        name: memberName.trim(),
-                        role: memberRole.trim(),
-                        allocation: Number(memberAllocation) || 0,
-                      });
-                      setMemberName("");
-                      setMemberRole("");
-                      setMemberAllocation("20");
-                    }}
-                  />
-                </View>
-
-                <View style={styles.dashboardColumn}>
-                  <ScrollView style={styles.embeddedScrollAreaTall}>
-                    <View style={styles.stackGap}>
-                      {state.members.map((member) => (
-                        <View key={member.id} style={styles.rowCard}>
-                          <View style={styles.rowMeta}>
-                            <Text style={styles.rowTitle}>{member.name}</Text>
-                            <Text style={styles.rowSubtitle}>{member.role}</Text>
-                          </View>
-                          <TextInputField
-                            label="Split %"
-                            value={`${member.allocation}`}
-                            keyboardType="numeric"
-                            onChangeText={(value) =>
-                              actions.updateMemberAllocation(member.id, Number(value) || 0)
-                            }
-                          />
-                          <View style={styles.actionRow}>
-                            <GhostButton label="Remove" onPress={() => actions.removeMember(member.id)} />
-                            <Text style={styles.moneyText}>
-                              {helpers.formatCurrency(totalTips * (member.allocation / 100))}
-                            </Text>
-                          </View>
-                        </View>
-                      ))}
-                    </View>
-                  </ScrollView>
-                </View>
-              </View>
-            </SectionCard>
-          ) : null}
-
-          {planningPanel === "settings" ? (
-            <SectionCard
-              title="Band links + device access"
-              eyebrow="Shared manager-owned configuration"
-            >
-              <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
-                <View style={styles.dashboardColumn}>
-                  <TextInputField label="Band name" value={bandName} onChangeText={setBandName} />
-                  <TextInputField label="Merch store" value={merchStore} onChangeText={setMerchStore} />
-                  <TextInputField label="Show calendar" value={showCalendar} onChangeText={setShowCalendar} />
-                  <TextInputField label="Venmo" value={venmo} onChangeText={setVenmo} />
-                  <TextInputField label="Cash App" value={cashapp} onChangeText={setCashapp} />
-                  <TextInputField label="PayPal" value={paypal} onChangeText={setPaypal} />
-                  <PrimaryButton
-                    label="Save band links"
-                    onPress={() =>
-                      actions.updateProfile({
-                        bandName: bandName.trim() || state.bandName,
-                        merchStore: merchStore.trim(),
-                        showCalendar: showCalendar.trim(),
-                        venmo: venmo.trim(),
-                        cashapp: cashapp.trim(),
-                        paypal: paypal.trim(),
-                      })
+                    onChangeText={(value) =>
+                      actions.updateMemberAllocation(member.id, Number(value) || 0)
                     }
                   />
+                  <View style={styles.actionRow}>
+                    <GhostButton label="Remove" onPress={() => actions.removeMember(member.id)} />
+                    <Text style={styles.moneyText}>
+                      {helpers.formatCurrency(totalTips * (member.allocation / 100))}
+                    </Text>
+                  </View>
                 </View>
+              ))}
+            </View>
+          </ScrollView>
+        </SectionCard>
+      ) : null}
 
-                <View style={styles.dashboardColumn}>
-                  <TextInputField label="Manager PIN" value={managerPin} onChangeText={setManagerPin} />
-                  <TextInputField label="Member PIN" value={memberPin} onChangeText={setMemberPin} />
-                  <TextInputField label="Crowd label" value={crowdLabel} onChangeText={setCrowdLabel} />
-                  <PrimaryButton
-                    label="Save device access"
-                    onPress={() =>
-                      actions.updateAccess({
-                        managerPin: managerPin.trim(),
-                        memberPin: memberPin.trim(),
-                        crowdLabel: crowdLabel.trim(),
-                      })
-                    }
-                  />
-                  <Text style={styles.compactNote}>
-                    Song catalog editing lives under Planning / Pre-Show and then Catalog.
-                  </Text>
-                  <GhostButton
-                    label="Reload demo data"
-                    onPress={actions.resetDemoData}
-                  />
-                </View>
-              </View>
-            </SectionCard>
-          ) : null}
-        </View>
-      )}
+      {mode === "planning" && planningPanel === "settings" ? (
+        <SectionCard
+          title="Band links + device access"
+          eyebrow="Shared manager-owned configuration"
+        >
+          <TextInputField label="Band name" value={bandName} onChangeText={setBandName} />
+          <TextInputField label="Merch store" value={merchStore} onChangeText={setMerchStore} />
+          <TextInputField label="Show calendar" value={showCalendar} onChangeText={setShowCalendar} />
+          <TextInputField label="Venmo" value={venmo} onChangeText={setVenmo} />
+          <TextInputField label="Cash App" value={cashapp} onChangeText={setCashapp} />
+          <TextInputField label="PayPal" value={paypal} onChangeText={setPaypal} />
+          <PrimaryButton
+            label="Save band links"
+            onPress={() =>
+              actions.updateProfile({
+                bandName: bandName.trim() || state.bandName,
+                merchStore: merchStore.trim(),
+                showCalendar: showCalendar.trim(),
+                venmo: venmo.trim(),
+                cashapp: cashapp.trim(),
+                paypal: paypal.trim(),
+              })
+            }
+          />
+          <TextInputField label="Manager PIN" value={managerPin} onChangeText={setManagerPin} />
+          <TextInputField label="Member PIN" value={memberPin} onChangeText={setMemberPin} />
+          <TextInputField label="Crowd label" value={crowdLabel} onChangeText={setCrowdLabel} />
+          <PrimaryButton
+            label="Save device access"
+            onPress={() =>
+              actions.updateAccess({
+                managerPin: managerPin.trim(),
+                memberPin: memberPin.trim(),
+                crowdLabel: crowdLabel.trim(),
+              })
+            }
+          />
+          <GhostButton label="Reload demo data" onPress={actions.resetDemoData} />
+        </SectionCard>
+      ) : null}
     </View>
   );
 }

--- a/src/screens/ManagerView.tsx
+++ b/src/screens/ManagerView.tsx
@@ -6,7 +6,6 @@ import {
   GhostButton,
   MetricCard,
   PrimaryButton,
-  RequestCard,
   RowCard,
   SectionCard,
   TextInputField,
@@ -48,6 +47,7 @@ type ManagerActions = {
 };
 
 type ManagerMode = "active-show" | "planning";
+type PlanningPanel = "shows" | "catalog" | "band" | "settings";
 
 export function ManagerView({
   activeShow,
@@ -69,6 +69,7 @@ export function ManagerView({
   const { width } = useWindowDimensions();
   const isTablet = width >= 900;
   const [mode, setMode] = React.useState<ManagerMode>("active-show");
+  const [planningPanel, setPlanningPanel] = React.useState<PlanningPanel>("shows");
 
   const [songTitle, setSongTitle] = React.useState("");
   const [songArtist, setSongArtist] = React.useState("");
@@ -129,6 +130,8 @@ export function ManagerView({
 
   const requestTipTotal = sortedRequests.reduce((sum, request) => sum + request.tip, 0);
   const supportTipTotal = totalTips - requestTipTotal;
+  const topRequests = sortedRequests.slice(0, 5);
+  const quickAddSongs = state.songs.slice(0, 8);
 
   return (
     <View style={styles.sectionStack}>
@@ -138,8 +141,8 @@ export function ManagerView({
           <Text style={styles.sectionTitle}>Band manager workspace</Text>
         </View>
         <Text style={styles.sectionCopy}>
-          The manager side now splits into two jobs: run the current show, or prepare the next one.
-          No more mixing live room decisions with setup tasks in the same stack.
+          Active Show is now a fast live console. Planning / Pre-Show is a calmer workspace with
+          focused sections for bigger setup tasks.
         </Text>
       </View>
 
@@ -149,11 +152,6 @@ export function ManagerView({
         sideLabel={mode === "active-show" ? "Live desk" : "Prep mode"}
         sideTone={mode === "active-show" ? "good" : "warning"}
       >
-        <Text style={styles.leadCopy}>
-          {mode === "active-show"
-            ? "Focus on requests, set flow, tips, and what the room needs right now."
-            : "Focus on the catalog, upcoming show setup, band operations, and payout preparation."}
-        </Text>
         <View style={styles.tabRow}>
           {([
             ["active-show", "Active Show"],
@@ -173,6 +171,11 @@ export function ManagerView({
             );
           })}
         </View>
+        <Text style={styles.compactNote}>
+          {mode === "active-show"
+            ? "Run the room from here: queue, set flow, and tips."
+            : "Prep here without the noise of live-show controls."}
+        </Text>
       </SectionCard>
 
       {mode === "active-show" ? (
@@ -183,17 +186,17 @@ export function ManagerView({
           >
             <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
               <MetricCard
-                label="Queue pressure"
+                label="Requests"
                 value={`${sortedRequests.length}`}
-                detail={sortedRequests.length ? "Live requests competing for the next slot" : "No live requests right now"}
+                detail={topRequests.length ? "Top requests are ready to work" : "Queue is quiet"}
               />
               <MetricCard
-                label="Set progress"
-                value={`${activeSetSongs.length}`}
-                detail={activeSetSongs.length ? "Songs currently staged for this show" : "No set loaded yet"}
+                label="Set"
+                value={`${activeSetSongs.length} songs`}
+                detail={activeSetSongs[0] ? `Next up: ${activeSetSongs[0].song.title}` : "No set staged yet"}
               />
               <MetricCard
-                label="Tips tracked"
+                label="Tips"
                 value={helpers.formatCurrency(totalTips)}
                 detail={`${helpers.formatCurrency(requestTipTotal)} requests · ${helpers.formatCurrency(supportTipTotal)} support`}
               />
@@ -203,23 +206,61 @@ export function ManagerView({
           <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
             <View style={styles.dashboardColumn}>
               <SectionCard
-                title="Setlist control"
-                eyebrow={activeShow ? `${activeSetSongs.length} songs on deck` : "Activate a show to manage the set"}
+                title="Request queue"
+                eyebrow={topRequests.length ? "Showing the highest-priority songs first" : "No requests waiting"}
+              >
+                <ScrollView style={styles.embeddedScrollAreaTall}>
+                  <View style={styles.stackGap}>
+                    {topRequests.length ? (
+                      topRequests.map((request) => {
+                        const song = helpers.songById(request.songId);
+                        if (!song) {
+                          return null;
+                        }
+
+                        return (
+                          <View key={request.id} style={styles.rowCard}>
+                            <View style={styles.rowMeta}>
+                              <Text style={styles.rowTitle}>{song.title}</Text>
+                              <Text style={styles.rowSubtitle}>
+                                {request.requester} · {helpers.formatCurrency(request.tip)} · {request.upvotes} boosts
+                              </Text>
+                              {request.note ? <Text style={styles.compactNote}>{request.note}</Text> : null}
+                            </View>
+                            <View style={styles.actionRow}>
+                              <GhostButton label="Boost" onPress={() => actions.boostRequest(request.id)} />
+                              <GhostButton label="Clear" onPress={() => actions.clearRequest(request.id)} />
+                            </View>
+                          </View>
+                        );
+                      })
+                    ) : (
+                      <EmptyState label="The room is clear right now. New requests will land here." />
+                    )}
+                  </View>
+                </ScrollView>
+                {sortedRequests.length > topRequests.length ? (
+                  <Text style={styles.compactNote}>
+                    {sortedRequests.length - topRequests.length} more requests remain below the fold.
+                  </Text>
+                ) : null}
+              </SectionCard>
+            </View>
+
+            <View style={styles.dashboardColumn}>
+              <SectionCard
+                title="Running set"
+                eyebrow={activeShow ? `${activeSetSongs.length} songs staged` : "Activate a show to manage the set"}
               >
                 <ScrollView style={styles.embeddedScrollArea}>
                   <View style={styles.stackGap}>
                     {activeSetSongs.length ? (
-                      activeSetSongs.map(({ song, index }) => (
+                      activeSetSongs.slice(0, 6).map(({ song, index }) => (
                         <RowCard
                           key={`${song.id}-${index}`}
                           title={`${index + 1}. ${song.title}`}
                           subtitle={`${song.artist} · ${song.energy} energy`}
-                          aside={
-                            <GhostButton
-                              label="Remove"
-                              onPress={() => actions.removeSongFromSetList(song.id)}
-                            />
-                          }
+                          aside={<GhostButton label="Remove" onPress={() => actions.removeSongFromSetList(song.id)} />}
                         />
                       ))
                     ) : (
@@ -227,10 +268,10 @@ export function ManagerView({
                     )}
                   </View>
                 </ScrollView>
-                <Text style={styles.fieldLabel}>Quick add from catalog</Text>
+                <Text style={styles.fieldLabel}>Quick add</Text>
                 <ScrollView horizontal showsHorizontalScrollIndicator={false}>
                   <View style={styles.pillWrap}>
-                    {state.songs.map((song) => (
+                    {quickAddSongs.map((song) => (
                       <Pressable
                         key={song.id}
                         onPress={() => actions.addSongToSetList(song.id)}
@@ -244,92 +285,33 @@ export function ManagerView({
               </SectionCard>
 
               <SectionCard
-                title="Lineup on stage"
-                eyebrow={lineupMembers.length ? `${lineupMembers.length} people assigned tonight` : "No lineup assigned yet"}
+                title="Tonight"
+                eyebrow={lineupMembers.length ? `${lineupMembers.length} people assigned` : "No lineup assigned yet"}
               >
+                <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
+                  <MetricCard
+                    label="Request tips"
+                    value={helpers.formatCurrency(requestTipTotal)}
+                    detail={`${sortedRequests.length} request entries`}
+                  />
+                  <MetricCard
+                    label="Direct support"
+                    value={helpers.formatCurrency(supportTipTotal)}
+                    detail="Walk-up and support tips"
+                  />
+                </View>
                 <View style={styles.pillWrap}>
                   {lineupMembers.length ? (
                     lineupMembers.map((member) => (
                       <View key={member.id} style={styles.personPill}>
                         <Text style={styles.personPillTitle}>{member.name}</Text>
-                        <Text style={styles.personPillSubtitle}>
-                          {member.role} · {member.allocation}% split
-                        </Text>
+                        <Text style={styles.personPillSubtitle}>{member.role}</Text>
                       </View>
                     ))
                   ) : (
                     <EmptyState label="Assign a lineup in Planning / Pre-Show first." />
                   )}
                 </View>
-              </SectionCard>
-            </View>
-
-            <View style={styles.dashboardColumn}>
-              <SectionCard
-                title="Request queue"
-                eyebrow={sortedRequests.length ? "Moderate the room from highest demand down" : "No requests waiting"}
-              >
-                <ScrollView style={styles.embeddedScrollAreaTall}>
-                  <View style={styles.stackGap}>
-                    {sortedRequests.length ? (
-                      sortedRequests.map((request) => {
-                        const song = helpers.songById(request.songId);
-                        if (!song) {
-                          return null;
-                        }
-                        return (
-                          <RequestCard
-                            key={request.id}
-                            title={song.title}
-                            subtitle={`${song.artist} · ${request.requester}`}
-                            note={request.note || "No note from the crowd"}
-                            value={`${helpers.formatCurrency(request.tip)} · ${request.upvotes} boosts`}
-                            primaryLabel="Boost +$5"
-                            primaryAction={() => actions.boostRequest(request.id)}
-                            secondaryLabel="Clear"
-                            secondaryAction={() => actions.clearRequest(request.id)}
-                          />
-                        );
-                      })
-                    ) : (
-                      <EmptyState label="The room is clear right now. New requests will land here." />
-                    )}
-                  </View>
-                </ScrollView>
-              </SectionCard>
-
-              <SectionCard
-                title="Tip snapshot"
-                eyebrow={`${helpers.formatCurrency(totalTips)} tracked across the show`}
-              >
-                <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
-                  <MetricCard
-                    label="Request tips"
-                    value={helpers.formatCurrency(requestTipTotal)}
-                    detail={`${sortedRequests.length} crowd request entries`}
-                  />
-                  <MetricCard
-                    label="Direct support"
-                    value={helpers.formatCurrency(supportTipTotal)}
-                    detail="Walk-up and support tip log"
-                  />
-                </View>
-                <ScrollView style={styles.embeddedScrollArea}>
-                  <View style={styles.stackGap}>
-                    {state.members.map((member) => (
-                      <RowCard
-                        key={member.id}
-                        title={member.name}
-                        subtitle={`${member.role} · ${member.allocation}% share`}
-                        aside={
-                          <Text style={styles.moneyText}>
-                            {helpers.formatCurrency(totalTips * (member.allocation / 100))}
-                          </Text>
-                        }
-                      />
-                    ))}
-                  </View>
-                </ScrollView>
               </SectionCard>
             </View>
           </View>
@@ -340,10 +322,6 @@ export function ManagerView({
             title={activeShow?.venue || "Planning workspace"}
             eyebrow={activeShow ? `${helpers.formatDate(activeShow.date)} · ${activeShow.city}` : "Choose or create a show"}
           >
-            <Text style={styles.leadCopy}>
-              Use this mode before doors open: choose the target show, shape the lineup, prep the
-              set, and tighten payout settings.
-            </Text>
             <ScrollView horizontal showsHorizontalScrollIndicator={false}>
               <View style={styles.pillWrap}>
                 {state.shows.map((show) => {
@@ -354,9 +332,7 @@ export function ManagerView({
                       onPress={() => actions.setActiveShow(show.id)}
                       style={[styles.selectPill, selected && styles.selectPillActive]}
                     >
-                      <Text
-                        style={[styles.selectPillText, selected && styles.selectPillTextActive]}
-                      >
+                      <Text style={[styles.selectPillText, selected && styles.selectPillTextActive]}>
                         {show.venue}
                       </Text>
                     </Pressable>
@@ -364,268 +340,312 @@ export function ManagerView({
                 })}
               </View>
             </ScrollView>
+            <View style={styles.tabRow}>
+              {([
+                ["shows", "Shows"],
+                ["catalog", "Catalog"],
+                ["band", "Band"],
+                ["settings", "Settings"],
+              ] as [PlanningPanel, string][]).map(([value, label]) => {
+                const selected = planningPanel === value;
+                return (
+                  <Pressable
+                    key={value}
+                    onPress={() => setPlanningPanel(value)}
+                    style={[styles.tabPill, selected && styles.tabPillActive]}
+                  >
+                    <Text style={[styles.tabPillText, selected && styles.tabPillTextActive]}>
+                      {label}
+                    </Text>
+                  </Pressable>
+                );
+              })}
+            </View>
           </SectionCard>
 
-          <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
-            <View style={styles.dashboardColumn}>
-              <SectionCard
-                title="Show planning"
-                eyebrow={state.shows.length ? `${state.shows.length} shows in rotation` : "No shows created"}
-              >
-                <ScrollView style={styles.embeddedScrollArea}>
-                  <View style={styles.stackGap}>
-                    {state.shows.map((show) => (
-                      <RowCard
-                        key={show.id}
-                        title={`${show.venue} · ${show.city}`}
-                        subtitle={`${helpers.formatDate(show.date)} · ${show.notes || "No notes yet"}`}
-                        aside={
-                          <>
-                            <GhostButton label="Open" onPress={() => actions.setActiveShow(show.id)} />
-                            {state.shows.length > 1 ? (
-                              <GhostButton label="Remove" onPress={() => actions.removeShow(show.id)} />
-                            ) : null}
-                          </>
-                        }
-                      />
-                    ))}
-                  </View>
-                </ScrollView>
-                <TextInputField label="Show date" value={showDate} onChangeText={setShowDate} />
-                <TextInputField label="Venue" value={showVenue} onChangeText={setShowVenue} />
-                <TextInputField label="City" value={showCity} onChangeText={setShowCity} />
-                <TextInputField label="Notes" value={showNotes} onChangeText={setShowNotes} />
-                <PrimaryButton
-                  label="Add show"
-                  onPress={() => {
-                    if (!showDate.trim() || !showVenue.trim() || !showCity.trim()) {
-                      return;
-                    }
-                    actions.addShow({
-                      date: showDate.trim(),
-                      venue: showVenue.trim(),
-                      city: showCity.trim(),
-                      notes: showNotes.trim(),
-                    });
-                    setShowVenue("");
-                    setShowCity("");
-                    setShowNotes("");
-                  }}
-                />
-              </SectionCard>
-
-              <SectionCard
-                title="Lineup + setlist prep"
-                eyebrow={activeShow ? `Editing ${activeShow.venue}` : "Select a show first"}
-              >
-                <Text style={styles.fieldLabel}>Lineup</Text>
-                <View style={styles.pillWrap}>
-                  {state.members.map((member) => {
-                    const selected = activeShow?.lineup.includes(member.id) ?? false;
-                    return (
-                      <Pressable
-                        key={member.id}
-                        onPress={() => actions.toggleLineupMember(member.id)}
-                        style={[styles.togglePill, selected && styles.togglePillActive]}
-                      >
-                        <Text
-                          style={[styles.togglePillText, selected && styles.togglePillTextActive]}
-                        >
-                          {member.name}
-                        </Text>
-                      </Pressable>
-                    );
-                  })}
-                </View>
-                <Text style={styles.fieldLabel}>Prepared setlist</Text>
-                <ScrollView style={styles.embeddedScrollArea}>
-                  <View style={styles.stackGap}>
-                    {activeSetSongs.length ? (
-                      activeSetSongs.map(({ song, index }) => (
+          {planningPanel === "shows" ? (
+            <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
+              <View style={styles.dashboardColumn}>
+                <SectionCard
+                  title="Show roster"
+                  eyebrow={`${state.shows.length} shows in rotation`}
+                >
+                  <ScrollView style={styles.embeddedScrollAreaTall}>
+                    <View style={styles.stackGap}>
+                      {state.shows.map((show) => (
                         <RowCard
-                          key={`${song.id}-${index}-planning`}
-                          title={`${index + 1}. ${song.title}`}
-                          subtitle={`${song.artist} · ${song.energy} energy`}
+                          key={show.id}
+                          title={`${show.venue} · ${show.city}`}
+                          subtitle={`${helpers.formatDate(show.date)} · ${show.notes || "No notes yet"}`}
                           aside={
-                            <GhostButton
-                              label="Remove"
-                              onPress={() => actions.removeSongFromSetList(song.id)}
-                            />
+                            <>
+                              <GhostButton label="Open" onPress={() => actions.setActiveShow(show.id)} />
+                              {state.shows.length > 1 ? (
+                                <GhostButton label="Remove" onPress={() => actions.removeShow(show.id)} />
+                              ) : null}
+                            </>
                           }
                         />
-                      ))
-                    ) : (
-                      <EmptyState label="No songs staged for this show yet." />
-                    )}
-                  </View>
-                </ScrollView>
-                <Text style={styles.fieldLabel}>Add songs to this show</Text>
-                <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                      ))}
+                    </View>
+                  </ScrollView>
+                  <TextInputField label="Show date" value={showDate} onChangeText={setShowDate} />
+                  <TextInputField label="Venue" value={showVenue} onChangeText={setShowVenue} />
+                  <TextInputField label="City" value={showCity} onChangeText={setShowCity} />
+                  <TextInputField label="Notes" value={showNotes} onChangeText={setShowNotes} />
+                  <PrimaryButton
+                    label="Add show"
+                    onPress={() => {
+                      if (!showDate.trim() || !showVenue.trim() || !showCity.trim()) {
+                        return;
+                      }
+                      actions.addShow({
+                        date: showDate.trim(),
+                        venue: showVenue.trim(),
+                        city: showCity.trim(),
+                        notes: showNotes.trim(),
+                      });
+                      setShowVenue("");
+                      setShowCity("");
+                      setShowNotes("");
+                    }}
+                  />
+                </SectionCard>
+              </View>
+
+              <View style={styles.dashboardColumn}>
+                <SectionCard
+                  title="Show setup"
+                  eyebrow={activeShow ? `Editing ${activeShow.venue}` : "Select a show first"}
+                >
+                  <Text style={styles.fieldLabel}>Lineup</Text>
                   <View style={styles.pillWrap}>
-                    {state.songs.map((song) => (
-                      <Pressable
-                        key={`${song.id}-planning`}
-                        onPress={() => actions.addSongToSetList(song.id)}
-                        style={styles.selectPill}
-                      >
-                        <Text style={styles.selectPillText}>{song.title}</Text>
-                      </Pressable>
-                    ))}
-                  </View>
-                </ScrollView>
-              </SectionCard>
-            </View>
-
-            <View style={styles.dashboardColumn}>
-              <SectionCard
-                title="Song catalog"
-                eyebrow={`${state.songs.length} songs available for requests and sets`}
-              >
-                <TextInputField label="Song title" value={songTitle} onChangeText={setSongTitle} />
-                <TextInputField label="Artist" value={songArtist} onChangeText={setSongArtist} />
-                <Text style={styles.fieldLabel}>Energy</Text>
-                <View style={styles.pillWrap}>
-                  {(["Low", "Mid", "High"] as Song["energy"][]).map((energy) => {
-                    const selected = songEnergy === energy;
-                    return (
-                      <Pressable
-                        key={energy}
-                        onPress={() => setSongEnergy(energy)}
-                        style={[styles.selectPill, selected && styles.selectPillActive]}
-                      >
-                        <Text
-                          style={[styles.selectPillText, selected && styles.selectPillTextActive]}
+                    {state.members.map((member) => {
+                      const selected = activeShow?.lineup.includes(member.id) ?? false;
+                      return (
+                        <Pressable
+                          key={member.id}
+                          onPress={() => actions.toggleLineupMember(member.id)}
+                          style={[styles.togglePill, selected && styles.togglePillActive]}
                         >
-                          {energy}
-                        </Text>
-                      </Pressable>
-                    );
-                  })}
-                </View>
-                <PrimaryButton
-                  label="Add song"
-                  onPress={() => {
-                    if (!songTitle.trim() || !songArtist.trim()) {
-                      return;
-                    }
-                    actions.addSong({
-                      title: songTitle.trim(),
-                      artist: songArtist.trim(),
-                      energy: helpers.normalizeEnergy(songEnergy),
-                    });
-                    setSongTitle("");
-                    setSongArtist("");
-                    setSongEnergy("Mid");
-                  }}
-                />
-                <ScrollView style={styles.embeddedScrollArea}>
-                  <View style={styles.stackGap}>
-                    {state.songs.map((song) => (
-                      <RowCard
-                        key={song.id}
-                        title={song.title}
-                        subtitle={`${song.artist} · ${song.energy} energy`}
-                        aside={<GhostButton label="Remove" onPress={() => actions.removeSong(song.id)} />}
-                      />
-                    ))}
-                  </View>
-                </ScrollView>
-              </SectionCard>
-
-              <SectionCard
-                title="Band + payouts"
-                eyebrow={`${splitTotal}% total split configured`}
-                sideLabel={splitTotal === 100 ? "Balanced" : "Needs review"}
-                sideTone={splitTotal === 100 ? "good" : "warning"}
-              >
-                <TextInputField label="Member name" value={memberName} onChangeText={setMemberName} />
-                <TextInputField label="Role" value={memberRole} onChangeText={setMemberRole} />
-                <TextInputField
-                  label="Split %"
-                  value={memberAllocation}
-                  keyboardType="numeric"
-                  onChangeText={setMemberAllocation}
-                />
-                <PrimaryButton
-                  label="Add member"
-                  onPress={() => {
-                    if (!memberName.trim() || !memberRole.trim()) {
-                      return;
-                    }
-                    actions.addMember({
-                      name: memberName.trim(),
-                      role: memberRole.trim(),
-                      allocation: Number(memberAllocation) || 0,
-                    });
-                    setMemberName("");
-                    setMemberRole("");
-                    setMemberAllocation("20");
-                  }}
-                />
-                <ScrollView style={styles.embeddedScrollArea}>
-                  <View style={styles.stackGap}>
-                    {state.members.map((member) => (
-                      <View key={member.id} style={styles.rowCard}>
-                        <View style={styles.rowMeta}>
-                          <Text style={styles.rowTitle}>{member.name}</Text>
-                          <Text style={styles.rowSubtitle}>{member.role}</Text>
-                        </View>
-                        <TextInputField
-                          label="Split %"
-                          value={`${member.allocation}`}
-                          keyboardType="numeric"
-                          onChangeText={(value) =>
-                            actions.updateMemberAllocation(member.id, Number(value) || 0)
-                          }
-                        />
-                        <View style={styles.actionRow}>
-                          <GhostButton label="Remove" onPress={() => actions.removeMember(member.id)} />
-                          <Text style={styles.moneyText}>
-                            {helpers.formatCurrency(totalTips * (member.allocation / 100))}
+                          <Text style={[styles.togglePillText, selected && styles.togglePillTextActive]}>
+                            {member.name}
                           </Text>
-                        </View>
-                      </View>
-                    ))}
+                        </Pressable>
+                      );
+                    })}
                   </View>
-                </ScrollView>
-              </SectionCard>
-
-              <SectionCard title="Band links + device access" eyebrow="Manager-owned shared configuration">
-                <TextInputField label="Band name" value={bandName} onChangeText={setBandName} />
-                <TextInputField label="Merch store" value={merchStore} onChangeText={setMerchStore} />
-                <TextInputField label="Show calendar" value={showCalendar} onChangeText={setShowCalendar} />
-                <TextInputField label="Venmo" value={venmo} onChangeText={setVenmo} />
-                <TextInputField label="Cash App" value={cashapp} onChangeText={setCashapp} />
-                <TextInputField label="PayPal" value={paypal} onChangeText={setPaypal} />
-                <PrimaryButton
-                  label="Save band links"
-                  onPress={() =>
-                    actions.updateProfile({
-                      bandName: bandName.trim() || state.bandName,
-                      merchStore: merchStore.trim(),
-                      showCalendar: showCalendar.trim(),
-                      venmo: venmo.trim(),
-                      cashapp: cashapp.trim(),
-                      paypal: paypal.trim(),
-                    })
-                  }
-                />
-                <TextInputField label="Manager PIN" value={managerPin} onChangeText={setManagerPin} />
-                <TextInputField label="Member PIN" value={memberPin} onChangeText={setMemberPin} />
-                <TextInputField label="Crowd label" value={crowdLabel} onChangeText={setCrowdLabel} />
-                <PrimaryButton
-                  label="Save device access"
-                  onPress={() =>
-                    actions.updateAccess({
-                      managerPin: managerPin.trim(),
-                      memberPin: memberPin.trim(),
-                      crowdLabel: crowdLabel.trim(),
-                    })
-                  }
-                />
-              </SectionCard>
+                  <Text style={styles.fieldLabel}>Prepared setlist</Text>
+                  <ScrollView style={styles.embeddedScrollArea}>
+                    <View style={styles.stackGap}>
+                      {activeSetSongs.length ? (
+                        activeSetSongs.map(({ song, index }) => (
+                          <RowCard
+                            key={`${song.id}-${index}-planning`}
+                            title={`${index + 1}. ${song.title}`}
+                            subtitle={`${song.artist} · ${song.energy} energy`}
+                            aside={<GhostButton label="Remove" onPress={() => actions.removeSongFromSetList(song.id)} />}
+                          />
+                        ))
+                      ) : (
+                        <EmptyState label="No songs staged for this show yet." />
+                      )}
+                    </View>
+                  </ScrollView>
+                  <Text style={styles.fieldLabel}>Add songs to this show</Text>
+                  <ScrollView horizontal showsHorizontalScrollIndicator={false}>
+                    <View style={styles.pillWrap}>
+                      {state.songs.map((song) => (
+                        <Pressable
+                          key={`${song.id}-planning`}
+                          onPress={() => actions.addSongToSetList(song.id)}
+                          style={styles.selectPill}
+                        >
+                          <Text style={styles.selectPillText}>{song.title}</Text>
+                        </Pressable>
+                      ))}
+                    </View>
+                  </ScrollView>
+                </SectionCard>
+              </View>
             </View>
-          </View>
+          ) : null}
+
+          {planningPanel === "catalog" ? (
+            <SectionCard
+              title="Song catalog"
+              eyebrow={`${state.songs.length} songs available for requests and sets`}
+            >
+              <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
+                <View style={styles.dashboardColumn}>
+                  <TextInputField label="Song title" value={songTitle} onChangeText={setSongTitle} />
+                  <TextInputField label="Artist" value={songArtist} onChangeText={setSongArtist} />
+                  <Text style={styles.fieldLabel}>Energy</Text>
+                  <View style={styles.pillWrap}>
+                    {(["Low", "Mid", "High"] as Song["energy"][]).map((energy) => {
+                      const selected = songEnergy === energy;
+                      return (
+                        <Pressable
+                          key={energy}
+                          onPress={() => setSongEnergy(energy)}
+                          style={[styles.selectPill, selected && styles.selectPillActive]}
+                        >
+                          <Text style={[styles.selectPillText, selected && styles.selectPillTextActive]}>
+                            {energy}
+                          </Text>
+                        </Pressable>
+                      );
+                    })}
+                  </View>
+                  <PrimaryButton
+                    label="Add song"
+                    onPress={() => {
+                      if (!songTitle.trim() || !songArtist.trim()) {
+                        return;
+                      }
+                      actions.addSong({
+                        title: songTitle.trim(),
+                        artist: songArtist.trim(),
+                        energy: helpers.normalizeEnergy(songEnergy),
+                      });
+                      setSongTitle("");
+                      setSongArtist("");
+                      setSongEnergy("Mid");
+                    }}
+                  />
+                </View>
+
+                <View style={styles.dashboardColumn}>
+                  <ScrollView style={styles.embeddedScrollAreaTall}>
+                    <View style={styles.stackGap}>
+                      {state.songs.map((song) => (
+                        <RowCard
+                          key={song.id}
+                          title={song.title}
+                          subtitle={`${song.artist} · ${song.energy} energy`}
+                          aside={<GhostButton label="Remove" onPress={() => actions.removeSong(song.id)} />}
+                        />
+                      ))}
+                    </View>
+                  </ScrollView>
+                </View>
+              </View>
+            </SectionCard>
+          ) : null}
+
+          {planningPanel === "band" ? (
+            <SectionCard
+              title="Band + payouts"
+              eyebrow={`${splitTotal}% total split configured`}
+              sideLabel={splitTotal === 100 ? "Balanced" : "Needs review"}
+              sideTone={splitTotal === 100 ? "good" : "warning"}
+            >
+              <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
+                <View style={styles.dashboardColumn}>
+                  <TextInputField label="Member name" value={memberName} onChangeText={setMemberName} />
+                  <TextInputField label="Role" value={memberRole} onChangeText={setMemberRole} />
+                  <TextInputField
+                    label="Split %"
+                    value={memberAllocation}
+                    keyboardType="numeric"
+                    onChangeText={setMemberAllocation}
+                  />
+                  <PrimaryButton
+                    label="Add member"
+                    onPress={() => {
+                      if (!memberName.trim() || !memberRole.trim()) {
+                        return;
+                      }
+                      actions.addMember({
+                        name: memberName.trim(),
+                        role: memberRole.trim(),
+                        allocation: Number(memberAllocation) || 0,
+                      });
+                      setMemberName("");
+                      setMemberRole("");
+                      setMemberAllocation("20");
+                    }}
+                  />
+                </View>
+
+                <View style={styles.dashboardColumn}>
+                  <ScrollView style={styles.embeddedScrollAreaTall}>
+                    <View style={styles.stackGap}>
+                      {state.members.map((member) => (
+                        <View key={member.id} style={styles.rowCard}>
+                          <View style={styles.rowMeta}>
+                            <Text style={styles.rowTitle}>{member.name}</Text>
+                            <Text style={styles.rowSubtitle}>{member.role}</Text>
+                          </View>
+                          <TextInputField
+                            label="Split %"
+                            value={`${member.allocation}`}
+                            keyboardType="numeric"
+                            onChangeText={(value) =>
+                              actions.updateMemberAllocation(member.id, Number(value) || 0)
+                            }
+                          />
+                          <View style={styles.actionRow}>
+                            <GhostButton label="Remove" onPress={() => actions.removeMember(member.id)} />
+                            <Text style={styles.moneyText}>
+                              {helpers.formatCurrency(totalTips * (member.allocation / 100))}
+                            </Text>
+                          </View>
+                        </View>
+                      ))}
+                    </View>
+                  </ScrollView>
+                </View>
+              </View>
+            </SectionCard>
+          ) : null}
+
+          {planningPanel === "settings" ? (
+            <SectionCard
+              title="Band links + device access"
+              eyebrow="Shared manager-owned configuration"
+            >
+              <View style={[styles.dashboardColumns, isTablet && styles.dashboardColumnsTablet]}>
+                <View style={styles.dashboardColumn}>
+                  <TextInputField label="Band name" value={bandName} onChangeText={setBandName} />
+                  <TextInputField label="Merch store" value={merchStore} onChangeText={setMerchStore} />
+                  <TextInputField label="Show calendar" value={showCalendar} onChangeText={setShowCalendar} />
+                  <TextInputField label="Venmo" value={venmo} onChangeText={setVenmo} />
+                  <TextInputField label="Cash App" value={cashapp} onChangeText={setCashapp} />
+                  <TextInputField label="PayPal" value={paypal} onChangeText={setPaypal} />
+                  <PrimaryButton
+                    label="Save band links"
+                    onPress={() =>
+                      actions.updateProfile({
+                        bandName: bandName.trim() || state.bandName,
+                        merchStore: merchStore.trim(),
+                        showCalendar: showCalendar.trim(),
+                        venmo: venmo.trim(),
+                        cashapp: cashapp.trim(),
+                        paypal: paypal.trim(),
+                      })
+                    }
+                  />
+                </View>
+
+                <View style={styles.dashboardColumn}>
+                  <TextInputField label="Manager PIN" value={managerPin} onChangeText={setManagerPin} />
+                  <TextInputField label="Member PIN" value={memberPin} onChangeText={setMemberPin} />
+                  <TextInputField label="Crowd label" value={crowdLabel} onChangeText={setCrowdLabel} />
+                  <PrimaryButton
+                    label="Save device access"
+                    onPress={() =>
+                      actions.updateAccess({
+                        managerPin: managerPin.trim(),
+                        memberPin: memberPin.trim(),
+                        crowdLabel: crowdLabel.trim(),
+                      })
+                    }
+                  />
+                </View>
+              </View>
+            </SectionCard>
+          ) : null}
         </View>
       )}
     </View>

--- a/src/screens/ManagerView.tsx
+++ b/src/screens/ManagerView.tsx
@@ -135,17 +135,6 @@ export function ManagerView({
 
   return (
     <View style={styles.sectionStack}>
-      <View style={styles.sectionHeader}>
-        <View>
-          <Text style={styles.eyebrow}>Manager mode</Text>
-          <Text style={styles.sectionTitle}>Band manager workspace</Text>
-        </View>
-        <Text style={styles.sectionCopy}>
-          Active Show is now a fast live console. Planning / Pre-Show is a calmer workspace with
-          focused sections for bigger setup tasks.
-        </Text>
-      </View>
-
       <SectionCard
         title={mode === "active-show" ? "Active Show" : "Planning / Pre-Show"}
         eyebrow={activeShow ? `${helpers.formatDate(activeShow.date)} · ${activeShow.venue}` : "No active show"}

--- a/src/screens/ManagerView.tsx
+++ b/src/screens/ManagerView.tsx
@@ -44,6 +44,7 @@ type ManagerActions = {
   removeSongFromSetList: (songId: string) => void;
   boostRequest: (requestId: string) => void;
   clearRequest: (requestId: string) => void;
+  resetDemoData: () => void;
 };
 
 type ManagerMode = "active-show" | "planning";
@@ -630,6 +631,13 @@ export function ManagerView({
                         crowdLabel: crowdLabel.trim(),
                       })
                     }
+                  />
+                  <Text style={styles.compactNote}>
+                    Song catalog editing lives under Planning / Pre-Show and then Catalog.
+                  </Text>
+                  <GhostButton
+                    label="Reload demo data"
+                    onPress={actions.resetDemoData}
                   />
                 </View>
               </View>

--- a/src/styles/appStyles.ts
+++ b/src/styles/appStyles.ts
@@ -127,6 +127,8 @@ export const appStyles = StyleSheet.create({
     justifyContent: "flex-end",
   },
   workspaceActionGroupStacked: {
+    flexDirection: "column",
+    alignItems: "stretch",
     justifyContent: "flex-start",
   },
   workspaceTitle: {

--- a/src/styles/appStyles.ts
+++ b/src/styles/appStyles.ts
@@ -236,6 +236,44 @@ export const appStyles = StyleSheet.create({
   tabPillTextActive: {
     color: "#fffaf2",
   },
+  toolbarShell: {
+    backgroundColor: colors.panel,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: 22,
+    padding: 12,
+    gap: 8,
+  },
+  toolbarRow: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+  toolbarPill: {
+    borderRadius: 999,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.card,
+  },
+  toolbarPillActive: {
+    backgroundColor: colors.text,
+    borderColor: colors.text,
+  },
+  toolbarPillText: {
+    color: colors.text,
+    fontWeight: "700",
+    fontSize: 12,
+  },
+  toolbarPillTextActive: {
+    color: "#fffaf2",
+  },
+  toolbarMeta: {
+    color: colors.muted,
+    fontSize: 13,
+    lineHeight: 18,
+  },
   fieldGroup: {
     gap: 6,
   },

--- a/src/styles/appStyles.ts
+++ b/src/styles/appStyles.ts
@@ -115,6 +115,7 @@ export const appStyles = StyleSheet.create({
     flex: 1,
   },
   workspaceHeaderStacked: {
+    flexDirection: "column",
     alignItems: "stretch",
   },
   workspaceHeaderCopyStacked: {
@@ -130,6 +131,7 @@ export const appStyles = StyleSheet.create({
     flexDirection: "column",
     alignItems: "stretch",
     justifyContent: "flex-start",
+    width: "100%",
   },
   workspaceTitle: {
     color: colors.text,

--- a/src/styles/appStyles.ts
+++ b/src/styles/appStyles.ts
@@ -114,11 +114,20 @@ export const appStyles = StyleSheet.create({
   workspaceHeaderCopy: {
     flex: 1,
   },
+  workspaceHeaderStacked: {
+    alignItems: "stretch",
+  },
+  workspaceHeaderCopyStacked: {
+    flex: 0,
+  },
   workspaceActionGroup: {
     flexDirection: "row",
     flexWrap: "wrap",
     gap: 10,
     justifyContent: "flex-end",
+  },
+  workspaceActionGroupStacked: {
+    justifyContent: "flex-start",
   },
   workspaceTitle: {
     color: colors.text,


### PR DESCRIPTION
## Summary
- expand the mock song catalog to better pressure-test list-heavy interfaces
- add multiple recent and upcoming mock shows with varied lineups and setlists
- seed a busier request queue and support-tip stream for live-state testing
- bump the local storage key so the simulator reloads the refreshed dataset

## Testing
- npx tsc --noEmit