### PR TITLE
Add active show request scheduling for #34

### DIFF
--- a/src/hooks/useStageHandState.ts
+++ b/src/hooks/useStageHandState.ts
@@ -7,6 +7,7 @@ import {
   formatCurrency,
   formatDate,
   formatLink,
+  getRequestInsertionIndex,
   mergeHydratedState,
   nextFriday,
   normalizeEnergy,
@@ -17,6 +18,7 @@ import {
   BandLinks,
   Member,
   RequestItem,
+  RequestSchedulingMode,
   Show,
   Song,
   StageHandState,
@@ -25,6 +27,13 @@ import {
 } from "../types/stagehand";
 
 const seedState = buildSeedState();
+
+const clampIndex = (value: number, max: number) => {
+  if (max <= 0) {
+    return 0;
+  }
+  return Math.max(0, Math.min(value, max));
+};
 
 export function useStageHandState() {
   const [state, setState] = useState<StageHandState>(seedState);
@@ -61,11 +70,13 @@ export function useStageHandState() {
   const supportTipTotal = state.supportTips.reduce((sum, tip) => sum + tip.amount, 0);
   const totalTips = requestTips + supportTipTotal;
   const splitTotal = state.members.reduce((sum, member) => sum + member.allocation, 0);
-  const sortedRequests = [...state.requests].sort((left, right) => {
-    const leftScore = left.tip * 100 + left.upvotes;
-    const rightScore = right.tip * 100 + right.upvotes;
-    return rightScore - leftScore;
-  });
+  const sortedRequests = state.requests
+    .filter((request) => request.status === "pending")
+    .sort((left, right) => {
+      const leftScore = left.tip * 100 + left.upvotes;
+      const rightScore = right.tip * 100 + right.upvotes;
+      return rightScore - leftScore;
+    });
 
   const songById = (songId: string) => state.songs.find((song) => song.id === songId);
   const memberById = (memberId: string) => state.members.find((member) => member.id === memberId);
@@ -168,11 +179,16 @@ export function useStageHandState() {
         ),
       }));
     },
-    addShow: (show: Omit<Show, "id" | "lineup" | "setList">) => {
+    addShow: (
+      show: Omit<Show, "id" | "lineup" | "setList" | "activeSetIndex" | "requestMode" | "manualRequestIds">,
+    ) => {
       const createdShow: Show = {
         id: createId(),
         lineup: [],
         setList: [],
+        activeSetIndex: 0,
+        requestMode: "auto",
+        manualRequestIds: [],
         ...show,
       };
 
@@ -182,7 +198,10 @@ export function useStageHandState() {
         activeShowId: createdShow.id,
       }));
     },
-    updateShow: (showId: string, updates: Omit<Show, "id" | "lineup" | "setList">) => {
+    updateShow: (
+      showId: string,
+      updates: Omit<Show, "id" | "lineup" | "setList" | "activeSetIndex" | "requestMode" | "manualRequestIds">,
+    ) => {
       replaceState((current) => ({
         ...current,
         shows: current.shows.map((show) =>
@@ -211,6 +230,9 @@ export function useStageHandState() {
           notes: "",
           lineup: current.members.map((member) => member.id),
           setList: [],
+          activeSetIndex: 0,
+          requestMode: "auto",
+          manualRequestIds: [],
         };
 
         return {
@@ -262,9 +284,72 @@ export function useStageHandState() {
           }
           const nextSetList = [...show.setList];
           nextSetList.splice(index, 1);
-          return { ...show, setList: nextSetList };
+          return {
+            ...show,
+            setList: nextSetList,
+            activeSetIndex:
+              index <= show.activeSetIndex
+                ? clampIndex(show.activeSetIndex - 1, nextSetList.length - 1)
+                : show.activeSetIndex,
+          };
         }),
       }));
+    },
+    setRequestMode: (mode: RequestSchedulingMode) => {
+      replaceState((current) => ({
+        ...current,
+        shows: current.shows.map((show) =>
+          show.id === current.activeShowId ? { ...show, requestMode: mode } : show,
+        ),
+      }));
+    },
+    setActiveSetIndex: (index: number) => {
+      replaceState((current) => ({
+        ...current,
+        shows: current.shows.map((show) =>
+          show.id === current.activeShowId
+            ? {
+                ...show,
+                activeSetIndex: clampIndex(index, show.setList.length - 1),
+              }
+            : show,
+        ),
+      }));
+    },
+    scheduleRequest: (requestId: string) => {
+      replaceState((current) => {
+        const request = current.requests.find((entry) => entry.id === requestId);
+        if (!request) {
+          return current;
+        }
+
+        return {
+          ...current,
+          shows: current.shows.map((show) => {
+            if (show.id !== current.activeShowId) {
+              return show;
+            }
+
+            const insertAt = getRequestInsertionIndex({
+              setList: show.setList,
+              songs: current.songs,
+              songId: request.songId,
+              activeSetIndex: show.activeSetIndex,
+            });
+            const nextSetList = [...show.setList];
+            nextSetList.splice(insertAt, 0, request.songId);
+
+            return {
+              ...show,
+              setList: nextSetList,
+              manualRequestIds: [...show.manualRequestIds, request.id],
+            };
+          }),
+          requests: current.requests.map((entry) =>
+            entry.id === requestId ? { ...entry, status: "scheduled" } : entry,
+          ),
+        };
+      });
     },
     updateProfile: (profile: BandLinks & { bandName: string }) => {
       replaceState((current) => ({
@@ -303,6 +388,7 @@ export function useStageHandState() {
             tip: payload.tip,
             upvotes: 1,
             createdAt: Date.now(),
+            status: "pending",
           },
         ],
       }));
@@ -321,6 +407,10 @@ export function useStageHandState() {
       replaceState((current) => ({
         ...current,
         requests: current.requests.filter((request) => request.id !== requestId),
+        shows: current.shows.map((show) => ({
+          ...show,
+          manualRequestIds: show.manualRequestIds.filter((entry) => entry !== requestId),
+        })),
       }));
     },
     addSupportTip: (payload: { supporter: string; amount: number; note: string }) => {

--- a/src/lib/stagehand.ts
+++ b/src/lib/stagehand.ts
@@ -1,6 +1,7 @@
 import { BandLinks, Member, Show, Song, SongEnergy, StageHandState, Venue } from "../types/stagehand";
 
-export const STORAGE_KEY = "stagehand-mobile-state-v3";
+export const STORAGE_KEY = "stagehand-mobile-state-v4";
+const energyOrder: Record<SongEnergy, number> = { Low: 0, Mid: 1, High: 2 };
 
 export const createId = () => Math.random().toString(36).slice(2, 10);
 
@@ -115,6 +116,9 @@ export const buildSeedState = (): StageHandState => {
     notes: "Acoustic first set, full band second set",
     lineup: members.map((member) => member.id),
     setList: songs.slice(0, 9).map((song) => song.id),
+    activeSetIndex: 0,
+    requestMode: "auto",
+    manualRequestIds: [],
   };
 
   const shows: Show[] = [
@@ -127,6 +131,9 @@ export const buildSeedState = (): StageHandState => {
       notes: "Private event load-in at 5pm",
       lineup: members.slice(0, 4).map((member) => member.id),
       setList: songs.slice(10, 18).map((song) => song.id),
+      activeSetIndex: 0,
+      requestMode: "manual",
+      manualRequestIds: [],
     },
     {
       id: createId(),
@@ -136,6 +143,9 @@ export const buildSeedState = (): StageHandState => {
       notes: "Crowd skewed younger, keep second set upbeat",
       lineup: members.map((member) => member.id),
       setList: songs.slice(18, 27).map((song) => song.id),
+      activeSetIndex: 0,
+      requestMode: "auto",
+      manualRequestIds: [],
     },
     {
       id: createId(),
@@ -145,6 +155,9 @@ export const buildSeedState = (): StageHandState => {
       notes: "Outdoor patio set with short break between sets",
       lineup: members.slice(0, 5).map((member) => member.id),
       setList: songs.slice(4, 13).map((song) => song.id),
+      activeSetIndex: 0,
+      requestMode: "auto",
+      manualRequestIds: [],
     },
     {
       id: createId(),
@@ -154,6 +167,9 @@ export const buildSeedState = (): StageHandState => {
       notes: "Late-night room, lean funk and dance-heavy",
       lineup: [members[0].id, members[1].id, members[2].id, members[3].id, members[5].id],
       setList: songs.slice(24, 33).map((song) => song.id),
+      activeSetIndex: 0,
+      requestMode: "manual",
+      manualRequestIds: [],
     },
     {
       id: createId(),
@@ -163,6 +179,9 @@ export const buildSeedState = (): StageHandState => {
       notes: "Venue wants a tighter first set and strong singalongs late",
       lineup: members.map((member) => member.id),
       setList: songs.slice(6, 15).map((song) => song.id),
+      activeSetIndex: 0,
+      requestMode: "auto",
+      manualRequestIds: [],
     },
     {
       id: createId(),
@@ -172,6 +191,9 @@ export const buildSeedState = (): StageHandState => {
       notes: "Travel date, compact backline, no percussion riser",
       lineup: members.slice(0, 5).map((member) => member.id),
       setList: songs.slice(14, 23).map((song) => song.id),
+      activeSetIndex: 0,
+      requestMode: "manual",
+      manualRequestIds: [],
     },
   ];
 
@@ -202,6 +224,7 @@ export const buildSeedState = (): StageHandState => {
         tip: 20,
         upvotes: 3,
         createdAt: Date.now() - 1000 * 60 * 30,
+        status: "pending",
       },
       {
         id: createId(),
@@ -211,6 +234,7 @@ export const buildSeedState = (): StageHandState => {
         tip: 12,
         upvotes: 1,
         createdAt: Date.now() - 1000 * 60 * 12,
+        status: "pending",
       },
       {
         id: createId(),
@@ -220,6 +244,7 @@ export const buildSeedState = (): StageHandState => {
         tip: 18,
         upvotes: 4,
         createdAt: Date.now() - 1000 * 60 * 28,
+        status: "pending",
       },
       {
         id: createId(),
@@ -229,6 +254,7 @@ export const buildSeedState = (): StageHandState => {
         tip: 15,
         upvotes: 5,
         createdAt: Date.now() - 1000 * 60 * 26,
+        status: "pending",
       },
       {
         id: createId(),
@@ -238,6 +264,7 @@ export const buildSeedState = (): StageHandState => {
         tip: 25,
         upvotes: 6,
         createdAt: Date.now() - 1000 * 60 * 22,
+        status: "pending",
       },
       {
         id: createId(),
@@ -247,6 +274,7 @@ export const buildSeedState = (): StageHandState => {
         tip: 9,
         upvotes: 2,
         createdAt: Date.now() - 1000 * 60 * 19,
+        status: "pending",
       },
       {
         id: createId(),
@@ -256,6 +284,7 @@ export const buildSeedState = (): StageHandState => {
         tip: 10,
         upvotes: 2,
         createdAt: Date.now() - 1000 * 60 * 16,
+        status: "pending",
       },
       {
         id: createId(),
@@ -265,6 +294,7 @@ export const buildSeedState = (): StageHandState => {
         tip: 30,
         upvotes: 7,
         createdAt: Date.now() - 1000 * 60 * 11,
+        status: "pending",
       },
       {
         id: createId(),
@@ -274,6 +304,7 @@ export const buildSeedState = (): StageHandState => {
         tip: 8,
         upvotes: 1,
         createdAt: Date.now() - 1000 * 60 * 9,
+        status: "pending",
       },
       {
         id: createId(),
@@ -283,6 +314,7 @@ export const buildSeedState = (): StageHandState => {
         tip: 14,
         upvotes: 3,
         createdAt: Date.now() - 1000 * 60 * 6,
+        status: "pending",
       },
     ],
     supportTips: [
@@ -356,6 +388,39 @@ export const normalizeEnergy = (value: string): SongEnergy => {
   return "Mid";
 };
 
+export const getRequestInsertionIndex = ({
+  setList,
+  songs,
+  songId,
+  activeSetIndex,
+}: {
+  setList: string[];
+  songs: Song[];
+  songId: string;
+  activeSetIndex: number;
+}) => {
+  const requestSong = songs.find((song) => song.id === songId);
+  if (!requestSong) {
+    return setList.length;
+  }
+
+  const requestEnergy = energyOrder[requestSong.energy];
+  const startIndex = Math.max(0, Math.min(activeSetIndex + 1, setList.length));
+
+  for (let index = startIndex; index < setList.length; index += 1) {
+    const stagedSong = songs.find((song) => song.id === setList[index]);
+    if (!stagedSong) {
+      continue;
+    }
+
+    if (energyOrder[stagedSong.energy] >= requestEnergy) {
+      return index;
+    }
+  }
+
+  return setList.length;
+};
+
 export const formatLink = (label: string, value: string) => {
   if (value.startsWith("http")) {
     return value;
@@ -383,8 +448,21 @@ export const mergeHydratedState = (
   songs: parsed.songs?.length ? parsed.songs : seedState.songs,
   members: parsed.members?.length ? parsed.members : seedState.members,
   venues: parsed.venues?.length ? parsed.venues : seedState.venues,
-  shows: parsed.shows?.length ? parsed.shows : seedState.shows,
-  requests: parsed.requests || seedState.requests,
+  shows:
+    parsed.shows?.map((show) => ({
+      ...show,
+      activeSetIndex:
+        typeof show.activeSetIndex === "number" && show.activeSetIndex >= 0
+          ? show.activeSetIndex
+          : 0,
+      requestMode: show.requestMode === "manual" ? "manual" : "auto",
+      manualRequestIds: show.manualRequestIds || [],
+    })) || seedState.shows,
+  requests:
+    parsed.requests?.map((request) => ({
+      ...request,
+      status: request.status === "scheduled" ? "scheduled" : "pending",
+    })) || seedState.requests,
   supportTips: parsed.supportTips || seedState.supportTips,
   activeShowId: parsed.activeShowId || parsed.shows?.[0]?.id || seedState.activeShowId,
 });

--- a/src/screens/ManagerView.tsx
+++ b/src/screens/ManagerView.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Pressable, ScrollView, Text, useWindowDimensions, View } from "react-native";
 
+import { getRequestInsertionIndex } from "../lib/stagehand";
 import {
   EmptyState,
   GhostButton,
@@ -10,7 +11,15 @@ import {
   TextInputField,
 } from "../components/ui";
 import { appStyles as styles } from "../styles/appStyles";
-import { Member, RequestItem, Show, Song, StageHandState, Venue } from "../types/stagehand";
+import {
+  Member,
+  RequestItem,
+  RequestSchedulingMode,
+  Show,
+  Song,
+  StageHandState,
+  Venue,
+} from "../types/stagehand";
 
 type ManagerHelpers = {
   formatCurrency: (value: number) => string;
@@ -39,13 +48,21 @@ type ManagerActions = {
   addVenue: (venue: Omit<Venue, "id">) => void;
   updateVenue: (venueId: string, updates: Omit<Venue, "id">) => void;
   removeVenue: (venueId: string) => void;
-  addShow: (show: Omit<Show, "id" | "lineup" | "setList">) => void;
-  updateShow: (showId: string, updates: Omit<Show, "id" | "lineup" | "setList">) => void;
+  addShow: (
+    show: Omit<Show, "id" | "lineup" | "setList" | "activeSetIndex" | "requestMode" | "manualRequestIds">,
+  ) => void;
+  updateShow: (
+    showId: string,
+    updates: Omit<Show, "id" | "lineup" | "setList" | "activeSetIndex" | "requestMode" | "manualRequestIds">,
+  ) => void;
   removeShow: (showId: string) => void;
   setActiveShow: (showId: string) => void;
   toggleLineupMember: (memberId: string) => void;
   addSongToSetList: (songId: string) => void;
   removeSongFromSetList: (songId: string) => void;
+  setRequestMode: (mode: RequestSchedulingMode) => void;
+  setActiveSetIndex: (index: number) => void;
+  scheduleRequest: (requestId: string) => void;
   boostRequest: (requestId: string) => void;
   clearRequest: (requestId: string) => void;
   resetDemoData: () => void;
@@ -54,6 +71,12 @@ type ManagerActions = {
 type ManagerMode = "active-show" | "planning";
 type ActivePanel = "queue" | "set" | "tonight";
 type PlanningPanel = "shows" | "venues" | "catalog" | "band" | "settings";
+type AutoPlacementPreviewItem = {
+  request: RequestItem;
+  song: Song;
+  insertAt: number;
+  anchorSong: Song | undefined;
+};
 
 function CompactListRow({
   title,
@@ -166,6 +189,11 @@ export function ManagerView({
   const selectedMember = state.members.find((member) => member.id === selectedMemberId) || null;
   const selectedRequest = sortedRequests.find((request) => request.id === selectedRequestId) || null;
   const selectedSetSong = state.songs.find((song) => song.id === selectedSetSongId) || null;
+  const scheduledRequests = activeShow
+    ? activeShow.manualRequestIds
+        .map((requestId) => state.requests.find((request) => request.id === requestId))
+        .filter((request): request is RequestItem => Boolean(request))
+    : [];
 
   React.useEffect(() => {
     if (!selectedShow) {
@@ -226,6 +254,32 @@ export function ManagerView({
   const supportTipTotal = totalTips - requestTipTotal;
   const topRequests = sortedRequests.slice(0, 10);
   const quickAddSongs = state.songs.slice(0, 12);
+  const currentSetEntry = activeShow ? activeSetSongs[activeShow.activeSetIndex] || activeSetSongs[0] || null : null;
+  const nextSetEntry = currentSetEntry ? activeSetSongs[currentSetEntry.index + 1] || null : activeSetSongs[0] || null;
+  const selectedRequestSong = selectedRequest ? helpers.songById(selectedRequest.songId) : undefined;
+  const autoPlacementPreview: AutoPlacementPreviewItem[] =
+    activeShow?.requestMode === "auto"
+      ? topRequests
+          .map((request) => {
+            const song = helpers.songById(request.songId);
+            if (!song || !activeShow) {
+              return null;
+            }
+            const insertAt = getRequestInsertionIndex({
+              setList: activeShow.setList,
+              songs: state.songs,
+              songId: request.songId,
+              activeSetIndex: activeShow.activeSetIndex,
+            });
+            const anchorSongId = activeShow.setList[insertAt];
+            const anchorSong = anchorSongId ? helpers.songById(anchorSongId) : undefined;
+            return { request, song, insertAt, anchorSong };
+          })
+          .filter((entry): entry is AutoPlacementPreviewItem => Boolean(entry))
+      : [];
+  const selectedAutoPlacement =
+    selectedRequest ? autoPlacementPreview.find((entry) => entry.request.id === selectedRequest.id) : undefined;
+  const visibleAutoPlacementPreview = autoPlacementPreview.slice(0, 5);
 
   const resetShowForm = () => {
     setSelectedShowId(null);
@@ -335,11 +389,39 @@ export function ManagerView({
         <SectionCard
           title="Request queue"
           eyebrow={topRequests.length ? `${sortedRequests.length} requests waiting` : "No requests waiting"}
+          sideLabel={activeShow?.requestMode === "manual" ? "Manual" : "Auto"}
+          sideTone={activeShow?.requestMode === "manual" ? "warning" : "good"}
         >
           <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
             <MetricCard label="Live requests" value={`${sortedRequests.length}`} detail="Highest-priority first" />
-            <MetricCard label="Request tips" value={helpers.formatCurrency(requestTipTotal)} detail="Crowd demand right now" />
+            <MetricCard
+              label="Request tips"
+              value={helpers.formatCurrency(requestTipTotal)}
+              detail="Crowd demand right now"
+            />
           </View>
+          <Text style={styles.fieldLabel}>Scheduling mode</Text>
+          <View style={styles.toolbarRow}>
+            {(["auto", "manual"] as RequestSchedulingMode[]).map((modeValue) => {
+              const selected = activeShow?.requestMode === modeValue;
+              return (
+                <Pressable
+                  key={modeValue}
+                  onPress={() => actions.setRequestMode(modeValue)}
+                  style={[styles.toolbarPill, selected && styles.toolbarPillActive]}
+                >
+                  <Text style={[styles.toolbarPillText, selected && styles.toolbarPillTextActive]}>
+                    {modeValue === "auto" ? "Auto interleave" : "Manual schedule"}
+                  </Text>
+                </Pressable>
+              );
+            })}
+          </View>
+          <Text style={styles.compactNote}>
+            {activeShow?.requestMode === "manual"
+              ? "Manual mode keeps requests in the queue until you place them into the set."
+              : "Auto mode keeps the queue live and slots requests into the next compatible energy window."}
+          </Text>
           <ScrollView style={styles.embeddedScrollAreaTall}>
             <View style={styles.compactList}>
               {topRequests.length ? (
@@ -367,12 +449,28 @@ export function ManagerView({
           </ScrollView>
           {selectedRequest ? (
             <SectionCard
-              title={helpers.songById(selectedRequest.songId)?.title || "Selected request"}
+              title={selectedRequestSong?.title || "Selected request"}
               eyebrow={`${selectedRequest.requester} · ${helpers.formatCurrency(selectedRequest.tip)} · ${selectedRequest.upvotes} boosts`}
             >
               <Text style={styles.leadCopy}>{selectedRequest.note || "No note from the crowd."}</Text>
+              <Text style={styles.compactNote}>
+                {activeShow?.requestMode === "manual"
+                  ? "Manual placement will insert this request at the next compatible energy point after the current song."
+                  : selectedAutoPlacement?.anchorSong
+                    ? `Auto will place this before ${selectedAutoPlacement.anchorSong.title}.`
+                    : "Auto will place this at the end of the staged set if no later energy match exists."}
+              </Text>
               <View style={styles.actionRow}>
                 <PrimaryButton label="Boost +$5" onPress={() => actions.boostRequest(selectedRequest.id)} />
+                {activeShow?.requestMode === "manual" ? (
+                  <GhostButton
+                    label="Add to set"
+                    onPress={() => {
+                      actions.scheduleRequest(selectedRequest.id);
+                      setSelectedRequestId(null);
+                    }}
+                  />
+                ) : null}
                 <GhostButton
                   label="Clear request"
                   onPress={() => {
@@ -385,6 +483,26 @@ export function ManagerView({
           ) : topRequests.length ? (
             <Text style={styles.compactNote}>Tap a request to view details and live actions.</Text>
           ) : null}
+          {activeShow?.requestMode === "manual" && scheduledRequests.length ? (
+            <>
+              <Text style={styles.fieldLabel}>Scheduled from queue</Text>
+              <View style={styles.compactList}>
+                {scheduledRequests.map((request, index) => {
+                  const song = helpers.songById(request.songId);
+                  if (!song) {
+                    return null;
+                  }
+                  return (
+                    <CompactListRow
+                      key={request.id}
+                      title={song.title}
+                      last={index === scheduledRequests.length - 1}
+                    />
+                  );
+                })}
+              </View>
+            </>
+          ) : null}
         </SectionCard>
       ) : null}
 
@@ -392,14 +510,31 @@ export function ManagerView({
         <SectionCard
           title="Running set"
           eyebrow={activeShow ? `${activeSetSongs.length} songs staged for ${activeShow.venue}` : "No active show selected"}
+          sideLabel={activeShow?.requestMode === "manual" ? "Manual" : "Auto"}
+          sideTone={activeShow?.requestMode === "manual" ? "warning" : "good"}
         >
           <View style={[styles.metricGrid, isTablet && styles.metricGridTablet]}>
             <MetricCard
-              label="Set size"
-              value={`${activeSetSongs.length}`}
-              detail={activeSetSongs[0] ? `Next up: ${activeSetSongs[0].song.title}` : "No next song staged"}
+              label="Current song"
+              value={currentSetEntry?.song.title || "None"}
+              detail={currentSetEntry ? `${currentSetEntry.song.energy} energy pocket` : "No song marked active yet"}
             />
-            <MetricCard label="Quick add" value={`${quickAddSongs.length}`} detail="Top catalog shortcuts below" />
+            <MetricCard
+              label="Up next"
+              value={nextSetEntry?.song.title || "Open slot"}
+              detail={nextSetEntry ? `Position ${nextSetEntry.index + 1}` : "Queue can fill the next move"}
+            />
+            <MetricCard label="Set size" value={`${activeSetSongs.length}`} detail="Current running order" />
+          </View>
+          <View style={styles.actionRow}>
+            <GhostButton
+              label="Previous song"
+              onPress={() => actions.setActiveSetIndex((activeShow?.activeSetIndex || 0) - 1)}
+            />
+            <GhostButton
+              label="Next song"
+              onPress={() => actions.setActiveSetIndex((activeShow?.activeSetIndex || 0) + 1)}
+            />
           </View>
           <ScrollView style={styles.embeddedScrollAreaTall}>
             <View style={styles.compactList}>
@@ -407,9 +542,12 @@ export function ManagerView({
                 activeSetSongs.map(({ song, index }) => (
                   <CompactListRow
                     key={`${song.id}-${index}`}
-                    title={song.title}
+                    title={`${index === (activeShow?.activeSetIndex || 0) ? "Now: " : ""}${song.title}`}
                     selected={selectedSetSongId === song.id}
-                    onPress={() => setSelectedSetSongId(song.id)}
+                    onPress={() => {
+                      setSelectedSetSongId(song.id);
+                      actions.setActiveSetIndex(index);
+                    }}
                     last={index === activeSetSongs.length - 1}
                   />
                 ))
@@ -440,6 +578,20 @@ export function ManagerView({
             </SectionCard>
           ) : activeSetSongs.length ? (
             <Text style={styles.compactNote}>Tap a set song to view details or remove it.</Text>
+          ) : null}
+          {activeShow?.requestMode === "auto" && autoPlacementPreview.length ? (
+            <>
+              <Text style={styles.fieldLabel}>Auto insertion preview</Text>
+              <View style={styles.compactList}>
+                {visibleAutoPlacementPreview.map((entry, index) => (
+                  <CompactListRow
+                    key={entry.request.id}
+                    title={`${entry.song.title} -> ${entry.anchorSong ? `before ${entry.anchorSong.title}` : "end of set"}`}
+                    last={index === visibleAutoPlacementPreview.length - 1}
+                  />
+                ))}
+              </View>
+            </>
           ) : null}
           <Text style={styles.fieldLabel}>Quick add from catalog</Text>
           <ScrollView style={styles.embeddedScrollArea}>

--- a/src/types/stagehand.ts
+++ b/src/types/stagehand.ts
@@ -7,6 +7,7 @@ export type DeviceSession = {
 };
 
 export type SongEnergy = "Low" | "Mid" | "High";
+export type RequestSchedulingMode = "auto" | "manual";
 
 export type Song = {
   id: string;
@@ -32,6 +33,9 @@ export type Show = {
   notes: string;
   lineup: string[];
   setList: string[];
+  activeSetIndex: number;
+  requestMode: RequestSchedulingMode;
+  manualRequestIds: string[];
 };
 
 export type Venue = {
@@ -50,6 +54,7 @@ export type RequestItem = {
   tip: number;
   upvotes: number;
   createdAt: number;
+  status: "pending" | "scheduled";
 };
 
 export type SupportTip = {


### PR DESCRIPTION
## Summary
- add active-show request scheduling state for auto and manual modes
- track the current set position and use it for energy-aware request insertion
- update the manager active-show queue and set panels for manual scheduling and auto placement preview

## Testing
- npx tsc --noEmit